### PR TITLE
管理ポータル: 備品管理・社員情報ページ追加 + ロール3階層化

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,7 +294,7 @@ model Admin {
   name          String
   email         String         @unique
   password      String
-  role          String         @default("admin") // admin, superadmin
+  role          String         @default("admin") // admin, superadmin, hr
   avatar        String?        @db.Text  // プロフィール画像URL（Vercel Blob）
   announcements  Announcement[]
   trainingVideos TrainingVideo[]
@@ -781,4 +781,75 @@ model FormSubmission {
 
   @@index([formId, createdAt])
   @@index([userId])
+}
+
+// 備品（社内商品）
+model Product {
+  id            String           @id @default(cuid())
+  name          String
+  purchasePrice Int              // 仕入れ価格（円）
+  sellingPrice  Int              // 販売価格（円）
+  stock         Int              @default(0)  // hasVariants=false 時の在庫
+  hasVariants   Boolean          @default(false)
+  supplierUrl   String?          @db.Text
+  supplierEmail String?
+  supplierNote  String?          @db.Text
+  variants      ProductVariant[]
+  createdAt     DateTime         @default(now())
+  updatedAt     DateTime         @updatedAt
+}
+
+model ProductVariant {
+  id           String   @id @default(cuid())
+  productId    String
+  product      Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  sizeName     String
+  stock        Int      @default(0)
+  sellingPrice Int?     // null の場合は Product.sellingPrice を使う
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([productId])
+}
+
+// 社員情報
+model Employee {
+  id                          String    @id @default(cuid())
+  employeeNumber              String    @unique
+  lastName                    String
+  firstName                   String
+  lastNameKana                String?
+  firstNameKana               String?
+  hireDate                    DateTime?
+  hireType                    String?   // 中途/新卒/その他
+  employmentType              String?   // 正社員/契約/パート/業務委託
+  department                  String?
+  jobTitle                    String?
+  jobCategory                 String?
+  jobDescription              String?   @db.Text
+  resignDate                  DateTime?
+  resignType                  String?
+  gender                      String?
+  workEmail                   String?
+  workPhone                   String?
+  dateOfBirth                 DateTime?
+  address                     String?   @db.Text
+  emergencyContact            String?   @db.Text
+  personalPhone               String?
+  // 暗号化フィールド（AES-256-GCM、@/lib/encrypt）
+  basicPensionNumberEnc        String?   @db.Text
+  healthInsuranceNumberEnc     String?   @db.Text
+  employmentInsuranceNumberEnc String?   @db.Text
+  residenceCardNumberEnc       String?   @db.Text
+  payrollBankInfoEnc           String?   @db.Text
+  qualifications              String?   @db.Text
+  resumeDriveUrl              String?   @db.Text
+  businessCardDriveUrl        String?   @db.Text
+  profilePhotoDriveUrl        String?   @db.Text
+  maritalStatus               String?   // single / married
+  createdAt                   DateTime  @default(now())
+  updatedAt                   DateTime  @updatedAt
+
+  @@index([department])
+  @@index([resignDate])
 }

--- a/src/app/(admin)/admin/employees/[id]/page.tsx
+++ b/src/app/(admin)/admin/employees/[id]/page.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useEffect, useState, use as usePromise } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import EmployeeForm, { EMPTY_EMPLOYEE, EmployeeFormState, buildEmployeePayload, fromEmployeeApi } from '@/components/admin/EmployeeForm'
+
+export default function EmployeeDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = usePromise(params)
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const role = (session?.user as any)?.role as string | undefined
+  const canSensitive = role === 'superadmin' || role === 'hr'
+  const canEdit = canSensitive
+  const canDelete = role === 'superadmin'
+
+  const [form, setForm] = useState<EmployeeFormState>(EMPTY_EMPLOYEE)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [msg, setMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+  const [internalId, setInternalId] = useState<string>('')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/admin/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    fetch(`/api/admin/employees/${id}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(api => {
+        if (api) {
+          setInternalId(api.id)
+          setForm(fromEmployeeApi(api))
+        }
+      })
+      .finally(() => setLoading(false))
+  }, [status, id])
+
+  function flash(kind: 'success' | 'error', text: string) {
+    setMsg({ kind, text })
+    setTimeout(() => setMsg(null), 3000)
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/admin/employees/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildEmployeePayload(form, canSensitive)),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        flash('error', j.error ?? '保存に失敗しました')
+        return
+      }
+      flash('success', '保存しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm('この社員情報を削除しますか？復元できません。')) return
+    const res = await fetch(`/api/admin/employees/${id}`, { method: 'DELETE' })
+    if (res.ok) router.push('/admin/employees')
+  }
+
+  if (status === 'loading' || loading) {
+    return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}><LoadingSpinner /></div>
+  }
+  if (!internalId) {
+    return <div style={{ padding: 40, textAlign: 'center' }}>社員が見つかりません</div>
+  }
+
+  return (
+    <div style={{ padding: '24px 20px', maxWidth: 960, margin: '0 auto', color: 'var(--md-sys-color-on-surface)' }}>
+      <button onClick={() => router.push('/admin/employees')} style={{ background: 'transparent', border: 'none', color: 'var(--md-sys-color-primary)', cursor: 'pointer', marginBottom: 12, padding: 0 }}>
+        ← 一覧に戻る
+      </button>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16, flexWrap: 'wrap', gap: 8 }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>{form.lastName} {form.firstName}</h1>
+        <code style={{ fontSize: 12, color: 'var(--md-sys-color-on-surface-variant)' }}>社員ID: {internalId}</code>
+      </div>
+
+      {!canSensitive && (
+        <div style={{ padding: 10, borderRadius: 8, marginBottom: 16, background: 'rgba(255, 152, 0, 0.15)', color: '#ffa726', fontSize: 13 }}>
+          機微情報の閲覧権限がありません。基本情報・雇用情報のみ表示されます。
+        </div>
+      )}
+      {msg && (
+        <div style={{ padding: 10, borderRadius: 8, marginBottom: 16, background: msg.kind === 'success' ? 'rgba(46, 125, 50, 0.15)' : 'rgba(211, 47, 47, 0.15)', color: msg.kind === 'success' ? '#66bb6a' : '#ef5350', fontSize: 13 }}>
+          {msg.text}
+        </div>
+      )}
+
+      <EmployeeForm value={form} onChange={setForm} showSensitive={canSensitive} disabled={!canEdit} />
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
+        <div>
+          {canDelete && (
+            <button onClick={handleDelete} style={{ padding: '8px 16px', borderRadius: 6, background: 'var(--md-sys-color-error)', color: 'var(--md-sys-color-on-error)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+              削除
+            </button>
+          )}
+        </div>
+        {canEdit && (
+          <button onClick={handleSave} disabled={saving} style={{ padding: '8px 16px', borderRadius: 6, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+            {saving ? '保存中…' : '保存'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/employees/new/page.tsx
+++ b/src/app/(admin)/admin/employees/new/page.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import EmployeeForm, { EMPTY_EMPLOYEE, EmployeeFormState, buildEmployeePayload } from '@/components/admin/EmployeeForm'
+
+export default function NewEmployeePage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const role = (session?.user as any)?.role as string | undefined
+  const canSensitive = role === 'superadmin' || role === 'hr'
+  const canEdit = canSensitive
+
+  const [form, setForm] = useState<EmployeeFormState>(EMPTY_EMPLOYEE)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/admin/login')
+    else if (status === 'authenticated' && !canEdit) router.push('/admin/employees')
+  }, [status, canEdit, router])
+
+  async function handleSave() {
+    setError('')
+    if (!form.employeeNumber.trim() || !form.lastName.trim() || !form.firstName.trim()) {
+      setError('従業員番号・苗字・名前は必須です')
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch('/api/admin/employees', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildEmployeePayload(form, canSensitive)),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        setError(j.error ?? '登録に失敗しました')
+        return
+      }
+      const created = await res.json()
+      router.push(`/admin/employees/${created.id}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (status !== 'authenticated' || !canEdit) {
+    return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}><LoadingSpinner /></div>
+  }
+
+  return (
+    <div style={{ padding: '24px 20px', maxWidth: 960, margin: '0 auto', color: 'var(--md-sys-color-on-surface)' }}>
+      <button onClick={() => router.push('/admin/employees')} style={{ background: 'transparent', border: 'none', color: 'var(--md-sys-color-primary)', cursor: 'pointer', marginBottom: 12, padding: 0 }}>
+        ← 一覧に戻る
+      </button>
+      <h1 style={{ fontSize: 24, fontWeight: 700, margin: '0 0 16px' }}>社員を追加</h1>
+      {error && <p style={{ color: 'var(--md-sys-color-error)', fontSize: 13, marginBottom: 12 }}>{error}</p>}
+
+      <EmployeeForm value={form} onChange={setForm} showSensitive={canSensitive} />
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+        <button onClick={() => router.push('/admin/employees')} style={{ padding: '8px 16px', borderRadius: 6, background: 'transparent', color: 'var(--md-sys-color-on-surface)', border: '1px solid var(--md-sys-color-outline)', fontSize: 14, cursor: 'pointer' }}>キャンセル</button>
+        <button onClick={handleSave} disabled={saving} style={{ padding: '8px 16px', borderRadius: 6, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+          {saving ? '保存中…' : '登録'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/employees/page.tsx
+++ b/src/app/(admin)/admin/employees/page.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+type Employee = {
+  id: string
+  employeeNumber: string
+  lastName: string
+  firstName: string
+  department: string | null
+  jobTitle: string | null
+  employmentType: string | null
+  workEmail: string | null
+  workPhone: string | null
+  hireDate: string | null
+  resignDate: string | null
+  profilePhotoDriveUrl: string | null
+}
+
+export default function EmployeeListPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const role = (session?.user as any)?.role as string | undefined
+  const canEdit = role === 'superadmin' || role === 'hr'
+
+  const [employees, setEmployees] = useState<Employee[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [showResigned, setShowResigned] = useState(false)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/admin/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    fetch('/api/admin/employees')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setEmployees)
+      .finally(() => setLoading(false))
+  }, [status])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    let list = employees
+    if (!showResigned) list = list.filter(e => !e.resignDate)
+    if (q) {
+      list = list.filter(e =>
+        [e.employeeNumber, e.lastName, e.firstName, e.department ?? '', e.jobTitle ?? '', e.workEmail ?? '']
+          .join(' ').toLowerCase().includes(q)
+      )
+    }
+    return list
+  }, [employees, search, showResigned])
+
+  if (status === 'loading' || loading) {
+    return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}><LoadingSpinner /></div>
+  }
+
+  return (
+    <div style={{ padding: '24px 20px', maxWidth: 1280, margin: '0 auto', color: 'var(--md-sys-color-on-surface)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20, gap: 12, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ margin: '0 0 4px', fontSize: 24, fontWeight: 700 }}>社員情報</h1>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--md-sys-color-on-surface-variant)' }}>
+            {role === 'admin'
+              ? '※ 機微情報は閲覧できません（基本情報のみ表示）'
+              : '社員の基本情報・人事情報・機微情報を管理'}
+            （{filtered.length}件 / 全{employees.length}件）
+          </p>
+        </div>
+        {canEdit && (
+          <button
+            onClick={() => router.push('/admin/employees/new')}
+            style={{ padding: '10px 16px', borderRadius: 8, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+          >
+            + 社員を追加
+          </button>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
+        <input
+          type="search"
+          placeholder="従業員番号・氏名・部署で検索"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ flex: '1 1 240px', maxWidth: 360, padding: '10px 12px', borderRadius: 8, border: '1px solid var(--md-sys-color-outline-variant)', background: 'var(--md-sys-color-surface-container)', color: 'var(--md-sys-color-on-surface)' }}
+        />
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+          <input type="checkbox" checked={showResigned} onChange={e => setShowResigned(e.target.checked)} />
+          退職者を表示
+        </label>
+      </div>
+
+      <div style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, overflow: 'hidden', border: '1px solid var(--md-sys-color-outline-variant)' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+          <thead>
+            <tr style={{ background: 'var(--md-sys-color-surface-container)', textAlign: 'left' }}>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>従業員番号</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>氏名</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>部署</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>肩書き</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>雇用形態</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>社用連絡先</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>状態</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && (
+              <tr><td colSpan={7} style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--md-sys-color-on-surface-variant)' }}>社員が登録されていません</td></tr>
+            )}
+            {filtered.map(e => (
+              <tr
+                key={e.id}
+                onClick={() => router.push(`/admin/employees/${e.id}`)}
+                style={{ borderTop: '1px solid var(--md-sys-color-outline-variant)', cursor: 'pointer' }}
+              >
+                <td style={{ padding: '12px 16px', fontFamily: 'monospace' }}>{e.employeeNumber}</td>
+                <td style={{ padding: '12px 16px', fontWeight: 600 }}>{e.lastName} {e.firstName}</td>
+                <td style={{ padding: '12px 16px' }}>{e.department ?? '—'}</td>
+                <td style={{ padding: '12px 16px' }}>{e.jobTitle ?? '—'}</td>
+                <td style={{ padding: '12px 16px' }}>{e.employmentType ?? '—'}</td>
+                <td style={{ padding: '12px 16px', fontSize: 12 }}>
+                  {e.workEmail && <div>{e.workEmail}</div>}
+                  {e.workPhone && <div>{e.workPhone}</div>}
+                  {!e.workEmail && !e.workPhone && '—'}
+                </td>
+                <td style={{ padding: '12px 16px' }}>
+                  {e.resignDate
+                    ? <span style={{ padding: '2px 8px', borderRadius: 12, background: 'rgba(211, 47, 47, 0.15)', color: '#ef5350', fontSize: 12 }}>退職</span>
+                    : <span style={{ padding: '2px 8px', borderRadius: 12, background: 'rgba(46, 125, 50, 0.15)', color: '#66bb6a', fontSize: 12 }}>在籍</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/inventory/[id]/page.tsx
+++ b/src/app/(admin)/admin/inventory/[id]/page.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useEffect, useState, use as usePromise } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+type Variant = {
+  id: string
+  sizeName: string
+  stock: number
+  sellingPrice: number | null
+}
+
+type Product = {
+  id: string
+  name: string
+  purchasePrice: number
+  sellingPrice: number
+  stock: number
+  hasVariants: boolean
+  supplierUrl: string | null
+  supplierEmail: string | null
+  supplierNote: string | null
+  variants: Variant[]
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 6,
+  border: '1px solid var(--md-sys-color-outline-variant)',
+  background: 'var(--md-sys-color-surface)',
+  color: 'var(--md-sys-color-on-surface)',
+  fontSize: 14,
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const primaryBtn: React.CSSProperties = {
+  padding: '8px 16px',
+  borderRadius: 6,
+  background: 'var(--md-sys-color-primary)',
+  color: 'var(--md-sys-color-on-primary)',
+  border: 'none',
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: 'pointer',
+}
+
+export default function InventoryDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = usePromise(params)
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const role = (session?.user as any)?.role as string | undefined
+  const canEdit = role === 'superadmin' || role === 'admin'
+
+  const [product, setProduct] = useState<Product | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [msg, setMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+
+  const [name, setName] = useState('')
+  const [purchasePrice, setPurchasePrice] = useState('0')
+  const [sellingPrice, setSellingPrice] = useState('0')
+  const [stock, setStock] = useState('0')
+  const [supplierUrl, setSupplierUrl] = useState('')
+  const [supplierEmail, setSupplierEmail] = useState('')
+  const [supplierNote, setSupplierNote] = useState('')
+
+  // new variant form
+  const [vSize, setVSize] = useState('')
+  const [vStock, setVStock] = useState('0')
+  const [vPrice, setVPrice] = useState('')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/admin/login')
+  }, [status, router])
+
+  function load() {
+    fetch(`/api/admin/inventory/${id}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((p: Product | null) => {
+        if (p) {
+          setProduct(p)
+          setName(p.name)
+          setPurchasePrice(String(p.purchasePrice))
+          setSellingPrice(String(p.sellingPrice))
+          setStock(String(p.stock))
+          setSupplierUrl(p.supplierUrl ?? '')
+          setSupplierEmail(p.supplierEmail ?? '')
+          setSupplierNote(p.supplierNote ?? '')
+        }
+      })
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, id])
+
+  function flash(kind: 'success' | 'error', text: string) {
+    setMsg({ kind, text })
+    setTimeout(() => setMsg(null), 3000)
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/admin/inventory/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          purchasePrice: Number(purchasePrice),
+          sellingPrice: Number(sellingPrice),
+          stock: Number(stock),
+          supplierUrl: supplierUrl || null,
+          supplierEmail: supplierEmail || null,
+          supplierNote: supplierNote || null,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        flash('error', j.error ?? '保存に失敗しました')
+        return
+      }
+      flash('success', '保存しました')
+      load()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAddVariant() {
+    if (!vSize.trim()) return
+    const res = await fetch(`/api/admin/inventory/${id}/variants`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sizeName: vSize.trim(),
+        stock: Number(vStock || '0'),
+        sellingPrice: vPrice ? Number(vPrice) : null,
+      }),
+    })
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}))
+      flash('error', j.error ?? '追加に失敗しました')
+      return
+    }
+    setVSize(''); setVStock('0'); setVPrice('')
+    load()
+  }
+
+  async function handleUpdateVariant(v: Variant, patch: Partial<Variant>) {
+    await fetch(`/api/admin/inventory/${id}/variants`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ variantId: v.id, ...patch }),
+    })
+    load()
+  }
+
+  async function handleDeleteVariant(v: Variant) {
+    if (!confirm(`サイズ「${v.sizeName}」を削除しますか？`)) return
+    await fetch(`/api/admin/inventory/${id}/variants`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ variantId: v.id }),
+    })
+    load()
+  }
+
+  async function handleDelete() {
+    if (!confirm('この商品を削除しますか？')) return
+    const res = await fetch(`/api/admin/inventory/${id}`, { method: 'DELETE' })
+    if (res.ok) router.push('/admin/inventory')
+  }
+
+  if (status === 'loading' || loading) {
+    return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}><LoadingSpinner /></div>
+  }
+  if (!product) {
+    return <div style={{ padding: 40, textAlign: 'center' }}>商品が見つかりません</div>
+  }
+
+  return (
+    <div style={{ padding: '24px 20px', maxWidth: 960, margin: '0 auto', color: 'var(--md-sys-color-on-surface)' }}>
+      <button onClick={() => router.push('/admin/inventory')} style={{ background: 'transparent', border: 'none', color: 'var(--md-sys-color-primary)', cursor: 'pointer', marginBottom: 12, padding: 0 }}>
+        ← 一覧に戻る
+      </button>
+      <h1 style={{ fontSize: 24, fontWeight: 700, margin: '0 0 16px' }}>{product.name}</h1>
+
+      {msg && (
+        <div style={{ padding: 10, borderRadius: 8, marginBottom: 16, background: msg.kind === 'success' ? 'rgba(46, 125, 50, 0.15)' : 'rgba(211, 47, 47, 0.15)', color: msg.kind === 'success' ? '#66bb6a' : '#ef5350', fontSize: 13 }}>
+          {msg.text}
+        </div>
+      )}
+
+      <section style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, padding: 20, marginBottom: 20, border: '1px solid var(--md-sys-color-outline-variant)' }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>基本情報</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <Field label="商品名"><input value={name} onChange={e => setName(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
+          <Field label="在庫数（バリアントなし時）"><input type="number" value={stock} onChange={e => setStock(e.target.value)} style={inputStyle} disabled={!canEdit || product.hasVariants} /></Field>
+          <Field label="仕入れ価格"><input type="number" value={purchasePrice} onChange={e => setPurchasePrice(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
+          <Field label="販売価格"><input type="number" value={sellingPrice} onChange={e => setSellingPrice(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
+          <Field label="発注先URL"><input value={supplierUrl} onChange={e => setSupplierUrl(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
+          <Field label="発注先メール"><input type="email" value={supplierEmail} onChange={e => setSupplierEmail(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
+          <div style={{ gridColumn: '1 / -1' }}>
+            <Field label="メモ"><textarea value={supplierNote} onChange={e => setSupplierNote(e.target.value)} style={{ ...inputStyle, minHeight: 60 }} disabled={!canEdit} /></Field>
+          </div>
+        </div>
+        {canEdit && (
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+            <button onClick={handleDelete} style={{ ...primaryBtn, background: 'var(--md-sys-color-error)', color: 'var(--md-sys-color-on-error)' }}>削除</button>
+            <button onClick={handleSave} disabled={saving} style={primaryBtn}>{saving ? '保存中…' : '保存'}</button>
+          </div>
+        )}
+      </section>
+
+      <section style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, padding: 20, border: '1px solid var(--md-sys-color-outline-variant)' }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>サイズバリアント</h2>
+        <p style={{ fontSize: 12, color: 'var(--md-sys-color-on-surface-variant)', margin: '0 0 12px' }}>
+          サイズを 1 つ以上追加すると、各サイズ単位で在庫を管理します。基本の在庫数フィールドは無効化されます。
+        </p>
+
+        {product.variants.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--md-sys-color-on-surface-variant)' }}>サイズバリアントは登録されていません</p>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14, marginBottom: 16 }}>
+            <thead>
+              <tr style={{ textAlign: 'left', borderBottom: '1px solid var(--md-sys-color-outline-variant)' }}>
+                <th style={{ padding: '8px 4px', fontWeight: 600 }}>サイズ名</th>
+                <th style={{ padding: '8px 4px', fontWeight: 600, textAlign: 'right' }}>在庫</th>
+                <th style={{ padding: '8px 4px', fontWeight: 600, textAlign: 'right' }}>販売価格（任意）</th>
+                {canEdit && <th></th>}
+              </tr>
+            </thead>
+            <tbody>
+              {product.variants.map(v => (
+                <tr key={v.id} style={{ borderBottom: '1px solid var(--md-sys-color-outline-variant)' }}>
+                  <td style={{ padding: '6px 4px' }}>
+                    <input
+                      defaultValue={v.sizeName}
+                      onBlur={e => e.target.value !== v.sizeName && handleUpdateVariant(v, { sizeName: e.target.value })}
+                      style={inputStyle}
+                      disabled={!canEdit}
+                    />
+                  </td>
+                  <td style={{ padding: '6px 4px' }}>
+                    <input
+                      type="number"
+                      defaultValue={v.stock}
+                      onBlur={e => Number(e.target.value) !== v.stock && handleUpdateVariant(v, { stock: Number(e.target.value) })}
+                      style={{ ...inputStyle, textAlign: 'right' }}
+                      disabled={!canEdit}
+                    />
+                  </td>
+                  <td style={{ padding: '6px 4px' }}>
+                    <input
+                      type="number"
+                      defaultValue={v.sellingPrice ?? ''}
+                      placeholder={String(product.sellingPrice)}
+                      onBlur={e => {
+                        const val = e.target.value === '' ? null : Number(e.target.value)
+                        if (val !== v.sellingPrice) handleUpdateVariant(v, { sellingPrice: val })
+                      }}
+                      style={{ ...inputStyle, textAlign: 'right' }}
+                      disabled={!canEdit}
+                    />
+                  </td>
+                  {canEdit && (
+                    <td style={{ padding: '6px 4px', textAlign: 'right' }}>
+                      <button onClick={() => handleDeleteVariant(v)} style={{ background: 'transparent', border: 'none', color: 'var(--md-sys-color-error)', cursor: 'pointer', fontSize: 13 }}>削除</button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {canEdit && (
+          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end', flexWrap: 'wrap' }}>
+            <div style={{ flex: '2 1 160px' }}>
+              <Field label="サイズ名"><input value={vSize} onChange={e => setVSize(e.target.value)} placeholder="S / M / 28cm など" style={inputStyle} /></Field>
+            </div>
+            <div style={{ flex: '1 1 80px' }}>
+              <Field label="在庫"><input type="number" value={vStock} onChange={e => setVStock(e.target.value)} style={inputStyle} /></Field>
+            </div>
+            <div style={{ flex: '1 1 100px' }}>
+              <Field label="販売価格（任意）"><input type="number" value={vPrice} onChange={e => setVPrice(e.target.value)} style={inputStyle} /></Field>
+            </div>
+            <button onClick={handleAddVariant} style={primaryBtn}>サイズを追加</button>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+      <span style={{ color: 'var(--md-sys-color-on-surface-variant)' }}>{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+type Variant = {
+  id: string
+  sizeName: string
+  stock: number
+  sellingPrice: number | null
+}
+
+type Product = {
+  id: string
+  name: string
+  purchasePrice: number
+  sellingPrice: number
+  stock: number
+  hasVariants: boolean
+  supplierUrl: string | null
+  supplierEmail: string | null
+  supplierNote: string | null
+  variants: Variant[]
+  updatedAt: string
+}
+
+type FormState = {
+  name: string
+  purchasePrice: string
+  sellingPrice: string
+  stock: string
+  supplierUrl: string
+  supplierEmail: string
+  supplierNote: string
+}
+
+const EMPTY: FormState = {
+  name: '',
+  purchasePrice: '',
+  sellingPrice: '',
+  stock: '0',
+  supplierUrl: '',
+  supplierEmail: '',
+  supplierNote: '',
+}
+
+export default function InventoryListPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const role = (session?.user as any)?.role as string | undefined
+  const canEdit = role === 'superadmin' || role === 'admin'
+
+  const [products, setProducts] = useState<Product[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [form, setForm] = useState<FormState>(EMPTY)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/admin/login')
+  }, [status, router])
+
+  function refresh() {
+    fetch('/api/admin/inventory')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setProducts)
+  }
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    fetch('/api/admin/inventory')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setProducts)
+      .finally(() => setLoading(false))
+  }, [status])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return products
+    return products.filter(p =>
+      [p.name, p.supplierEmail ?? '', p.supplierUrl ?? ''].join(' ').toLowerCase().includes(q)
+    )
+  }, [products, search])
+
+  async function handleCreate() {
+    setError('')
+    if (!form.name.trim()) {
+      setError('商品名は必須です')
+      return
+    }
+    const purchasePrice = Number(form.purchasePrice)
+    const sellingPrice = Number(form.sellingPrice)
+    const stock = Number(form.stock || '0')
+    if (!Number.isFinite(purchasePrice) || purchasePrice < 0) {
+      setError('仕入れ価格を正しく入力してください')
+      return
+    }
+    if (!Number.isFinite(sellingPrice) || sellingPrice < 0) {
+      setError('販売価格を正しく入力してください')
+      return
+    }
+    setSaving(true)
+    try {
+      const res = await fetch('/api/admin/inventory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          purchasePrice,
+          sellingPrice,
+          stock,
+          supplierUrl: form.supplierUrl.trim() || null,
+          supplierEmail: form.supplierEmail.trim() || null,
+          supplierNote: form.supplierNote.trim() || null,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        setError(j.error ?? '登録に失敗しました')
+        return
+      }
+      setModalOpen(false)
+      setForm(EMPTY)
+      refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (status === 'loading' || loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 80 }}>
+        <LoadingSpinner />
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '24px 20px', maxWidth: 1280, margin: '0 auto', color: 'var(--md-sys-color-on-surface)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20, gap: 12, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ margin: '0 0 4px', fontSize: 24, fontWeight: 700 }}>備品管理</h1>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--md-sys-color-on-surface-variant)' }}>
+            社内備品の在庫・仕入れ価格・販売価格・発注先を管理（{filtered.length}件 / 全{products.length}件）
+          </p>
+        </div>
+        {canEdit && (
+          <button
+            onClick={() => { setForm(EMPTY); setError(''); setModalOpen(true) }}
+            style={{ padding: '10px 16px', borderRadius: 8, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+          >
+            + 新規追加
+          </button>
+        )}
+      </div>
+
+      <div style={{ marginBottom: 16 }}>
+        <input
+          type="search"
+          placeholder="商品名・発注先で検索"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ width: '100%', maxWidth: 360, padding: '10px 12px', borderRadius: 8, border: '1px solid var(--md-sys-color-outline-variant)', background: 'var(--md-sys-color-surface-container)', color: 'var(--md-sys-color-on-surface)' }}
+        />
+      </div>
+
+      <div style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, overflow: 'hidden', border: '1px solid var(--md-sys-color-outline-variant)' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+          <thead>
+            <tr style={{ background: 'var(--md-sys-color-surface-container)', textAlign: 'left' }}>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>商品名</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>仕入れ価格</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>販売価格</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>在庫</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>サイズ</th>
+              <th style={{ padding: '12px 16px', fontWeight: 600 }}>発注先</th>
+              <th style={{ padding: '12px 16px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={7} style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--md-sys-color-on-surface-variant)' }}>
+                  商品が登録されていません
+                </td>
+              </tr>
+            )}
+            {filtered.map(p => {
+              const totalStock = p.hasVariants
+                ? p.variants.reduce((s, v) => s + v.stock, 0)
+                : p.stock
+              return (
+                <tr key={p.id} style={{ borderTop: '1px solid var(--md-sys-color-outline-variant)' }}>
+                  <td style={{ padding: '12px 16px', fontWeight: 600 }}>{p.name}</td>
+                  <td style={{ padding: '12px 16px', textAlign: 'right' }}>¥{p.purchasePrice.toLocaleString()}</td>
+                  <td style={{ padding: '12px 16px', textAlign: 'right' }}>¥{p.sellingPrice.toLocaleString()}</td>
+                  <td style={{ padding: '12px 16px', textAlign: 'right' }}>{totalStock}</td>
+                  <td style={{ padding: '12px 16px', fontSize: 12 }}>
+                    {p.hasVariants
+                      ? p.variants.map(v => `${v.sizeName}(${v.stock})`).join(' / ')
+                      : <span style={{ color: 'var(--md-sys-color-on-surface-variant)' }}>—</span>}
+                  </td>
+                  <td style={{ padding: '12px 16px', fontSize: 12 }}>
+                    {p.supplierUrl && <div><a href={p.supplierUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--md-sys-color-primary)' }}>{p.supplierUrl}</a></div>}
+                    {p.supplierEmail && <div>{p.supplierEmail}</div>}
+                    {!p.supplierUrl && !p.supplierEmail && <span style={{ color: 'var(--md-sys-color-on-surface-variant)' }}>—</span>}
+                  </td>
+                  <td style={{ padding: '12px 16px', textAlign: 'right' }}>
+                    <button
+                      onClick={() => router.push(`/admin/inventory/${p.id}`)}
+                      style={{ padding: '6px 12px', borderRadius: 6, background: 'transparent', color: 'var(--md-sys-color-primary)', border: '1px solid var(--md-sys-color-outline)', fontSize: 13, cursor: 'pointer' }}
+                    >
+                      詳細
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {modalOpen && (
+        <div
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100, padding: 16 }}
+          onClick={() => !saving && setModalOpen(false)}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: 'var(--md-sys-color-surface-container-high)', borderRadius: 12, padding: 24, width: '100%', maxWidth: 520, color: 'var(--md-sys-color-on-surface)' }}
+          >
+            <h2 style={{ margin: '0 0 16px', fontSize: 18, fontWeight: 700 }}>商品を追加</h2>
+            {error && <p style={{ color: 'var(--md-sys-color-error)', fontSize: 13, marginBottom: 12 }}>{error}</p>}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <Field label="商品名 *">
+                <input value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} style={inputStyle} />
+              </Field>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
+                <Field label="仕入れ価格 *">
+                  <input type="number" min={0} value={form.purchasePrice} onChange={e => setForm({ ...form, purchasePrice: e.target.value })} style={inputStyle} />
+                </Field>
+                <Field label="販売価格 *">
+                  <input type="number" min={0} value={form.sellingPrice} onChange={e => setForm({ ...form, sellingPrice: e.target.value })} style={inputStyle} />
+                </Field>
+                <Field label="在庫数">
+                  <input type="number" min={0} value={form.stock} onChange={e => setForm({ ...form, stock: e.target.value })} style={inputStyle} />
+                </Field>
+              </div>
+              <Field label="発注先URL">
+                <input value={form.supplierUrl} onChange={e => setForm({ ...form, supplierUrl: e.target.value })} style={inputStyle} placeholder="https://..." />
+              </Field>
+              <Field label="発注先メールアドレス">
+                <input type="email" value={form.supplierEmail} onChange={e => setForm({ ...form, supplierEmail: e.target.value })} style={inputStyle} />
+              </Field>
+              <Field label="メモ">
+                <textarea value={form.supplierNote} onChange={e => setForm({ ...form, supplierNote: e.target.value })} style={{ ...inputStyle, minHeight: 60 }} />
+              </Field>
+              <p style={{ fontSize: 12, color: 'var(--md-sys-color-on-surface-variant)', margin: 0 }}>
+                ※ サイズバリアントは作成後の詳細ページで追加できます
+              </p>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
+              <button onClick={() => setModalOpen(false)} disabled={saving} style={cancelBtn}>キャンセル</button>
+              <button onClick={handleCreate} disabled={saving} style={primaryBtn}>{saving ? '保存中…' : '登録'}</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+      <span style={{ color: 'var(--md-sys-color-on-surface-variant)' }}>{label}</span>
+      {children}
+    </label>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 6,
+  border: '1px solid var(--md-sys-color-outline-variant)',
+  background: 'var(--md-sys-color-surface)',
+  color: 'var(--md-sys-color-on-surface)',
+  fontSize: 14,
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const primaryBtn: React.CSSProperties = {
+  padding: '8px 16px',
+  borderRadius: 6,
+  background: 'var(--md-sys-color-primary)',
+  color: 'var(--md-sys-color-on-primary)',
+  border: 'none',
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: 'pointer',
+}
+
+const cancelBtn: React.CSSProperties = {
+  padding: '8px 16px',
+  borderRadius: 6,
+  background: 'transparent',
+  color: 'var(--md-sys-color-on-surface)',
+  border: '1px solid var(--md-sys-color-outline)',
+  fontSize: 14,
+  cursor: 'pointer',
+}

--- a/src/app/api/admin/employees/[id]/route.ts
+++ b/src/app/api/admin/employees/[id]/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { requireAdmin, canViewEmployee, canEditEmployee, canViewSensitiveEmployee } from '@/lib/admin-auth'
+import { encField, serializeEmployee, HIRE_TYPES, EMPLOYMENT_TYPES, RESIGN_TYPES, GENDERS, MARITAL_STATUSES } from '@/lib/employee-utils'
+
+const dateLike = z.string().datetime().or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).nullable().optional()
+
+const updateSchema = z.object({
+  employeeNumber: z.string().min(1).max(40).optional(),
+  lastName: z.string().min(1).max(60).optional(),
+  firstName: z.string().min(1).max(60).optional(),
+  lastNameKana: z.string().max(80).nullable().optional(),
+  firstNameKana: z.string().max(80).nullable().optional(),
+  hireDate: dateLike,
+  hireType: z.enum(HIRE_TYPES).nullable().optional(),
+  employmentType: z.enum(EMPLOYMENT_TYPES).nullable().optional(),
+  department: z.string().max(80).nullable().optional(),
+  jobTitle: z.string().max(80).nullable().optional(),
+  jobCategory: z.string().max(80).nullable().optional(),
+  jobDescription: z.string().max(2000).nullable().optional(),
+  resignDate: dateLike,
+  resignType: z.enum(RESIGN_TYPES).nullable().optional(),
+  gender: z.enum(GENDERS).nullable().optional(),
+  workEmail: z.string().email().nullable().optional().or(z.literal('')),
+  workPhone: z.string().max(40).nullable().optional(),
+  dateOfBirth: dateLike,
+  address: z.string().max(500).nullable().optional(),
+  emergencyContact: z.string().max(500).nullable().optional(),
+  personalPhone: z.string().max(40).nullable().optional(),
+  basicPensionNumber: z.string().max(40).nullable().optional(),
+  healthInsuranceNumber: z.string().max(40).nullable().optional(),
+  employmentInsuranceNumber: z.string().max(40).nullable().optional(),
+  residenceCardNumber: z.string().max(40).nullable().optional(),
+  payrollBankInfo: z.string().max(1000).nullable().optional(),
+  qualifications: z.string().max(2000).nullable().optional(),
+  resumeDriveUrl: z.string().max(500).nullable().optional(),
+  businessCardDriveUrl: z.string().max(500).nullable().optional(),
+  profilePhotoDriveUrl: z.string().max(500).nullable().optional(),
+  maritalStatus: z.enum(MARITAL_STATUSES).nullable().optional(),
+})
+
+const SENSITIVE_KEYS = [
+  'basicPensionNumber', 'healthInsuranceNumber', 'employmentInsuranceNumber',
+  'residenceCardNumber', 'payrollBankInfo',
+] as const
+
+export async function GET(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canViewEmployee(user.role)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { id } = await ctx.params
+  const employee = await prisma.employee.findUnique({ where: { id } })
+  if (!employee) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(serializeEmployee(employee, user.role))
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditEmployee(user.role)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { id } = await ctx.params
+  const body = await req.json()
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+  const d = parsed.data
+
+  const touchingSensitive = SENSITIVE_KEYS.some(k => k in body)
+  if (touchingSensitive && !canViewSensitiveEmployee(user.role)) {
+    return NextResponse.json({ error: '機微情報の編集権限がありません' }, { status: 403 })
+  }
+
+  const data: any = {}
+  const passthrough = [
+    'employeeNumber', 'lastName', 'firstName', 'lastNameKana', 'firstNameKana',
+    'hireType', 'employmentType', 'department', 'jobTitle', 'jobCategory', 'jobDescription',
+    'resignType', 'gender', 'workEmail', 'workPhone', 'address', 'emergencyContact', 'personalPhone',
+    'qualifications', 'resumeDriveUrl', 'businessCardDriveUrl', 'profilePhotoDriveUrl', 'maritalStatus',
+  ] as const
+  for (const k of passthrough) {
+    if (k in d) data[k] = (d as any)[k] === '' ? null : (d as any)[k]
+  }
+  if ('hireDate' in d) data.hireDate = d.hireDate ? new Date(d.hireDate) : null
+  if ('resignDate' in d) data.resignDate = d.resignDate ? new Date(d.resignDate) : null
+  if ('dateOfBirth' in d) data.dateOfBirth = d.dateOfBirth ? new Date(d.dateOfBirth) : null
+
+  if ('basicPensionNumber' in d) data.basicPensionNumberEnc = encField(d.basicPensionNumber ?? null)
+  if ('healthInsuranceNumber' in d) data.healthInsuranceNumberEnc = encField(d.healthInsuranceNumber ?? null)
+  if ('employmentInsuranceNumber' in d) data.employmentInsuranceNumberEnc = encField(d.employmentInsuranceNumber ?? null)
+  if ('residenceCardNumber' in d) data.residenceCardNumberEnc = encField(d.residenceCardNumber ?? null)
+  if ('payrollBankInfo' in d) data.payrollBankInfoEnc = encField(d.payrollBankInfo ?? null)
+
+  const updated = await prisma.employee.update({ where: { id }, data })
+  return NextResponse.json(serializeEmployee(updated, user.role))
+}
+
+export async function DELETE(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || user.role !== 'superadmin') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  await prisma.employee.delete({ where: { id } })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/admin/employees/route.ts
+++ b/src/app/api/admin/employees/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { requireAdmin, canViewEmployee, canEditEmployee, canViewSensitiveEmployee } from '@/lib/admin-auth'
+import { encField, serializeEmployee, HIRE_TYPES, EMPLOYMENT_TYPES, RESIGN_TYPES, GENDERS, MARITAL_STATUSES } from '@/lib/employee-utils'
+
+const dateLike = z.string().datetime().or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).nullable().optional()
+
+const baseSchema = z.object({
+  employeeNumber: z.string().min(1).max(40),
+  lastName: z.string().min(1).max(60),
+  firstName: z.string().min(1).max(60),
+  lastNameKana: z.string().max(80).nullable().optional(),
+  firstNameKana: z.string().max(80).nullable().optional(),
+  hireDate: dateLike,
+  hireType: z.enum(HIRE_TYPES).nullable().optional(),
+  employmentType: z.enum(EMPLOYMENT_TYPES).nullable().optional(),
+  department: z.string().max(80).nullable().optional(),
+  jobTitle: z.string().max(80).nullable().optional(),
+  jobCategory: z.string().max(80).nullable().optional(),
+  jobDescription: z.string().max(2000).nullable().optional(),
+  resignDate: dateLike,
+  resignType: z.enum(RESIGN_TYPES).nullable().optional(),
+  gender: z.enum(GENDERS).nullable().optional(),
+  workEmail: z.string().email().nullable().optional().or(z.literal('')),
+  workPhone: z.string().max(40).nullable().optional(),
+  dateOfBirth: dateLike,
+  address: z.string().max(500).nullable().optional(),
+  emergencyContact: z.string().max(500).nullable().optional(),
+  personalPhone: z.string().max(40).nullable().optional(),
+  basicPensionNumber: z.string().max(40).nullable().optional(),
+  healthInsuranceNumber: z.string().max(40).nullable().optional(),
+  employmentInsuranceNumber: z.string().max(40).nullable().optional(),
+  residenceCardNumber: z.string().max(40).nullable().optional(),
+  payrollBankInfo: z.string().max(1000).nullable().optional(),
+  qualifications: z.string().max(2000).nullable().optional(),
+  resumeDriveUrl: z.string().max(500).nullable().optional(),
+  businessCardDriveUrl: z.string().max(500).nullable().optional(),
+  profilePhotoDriveUrl: z.string().max(500).nullable().optional(),
+  maritalStatus: z.enum(MARITAL_STATUSES).nullable().optional(),
+})
+
+export async function GET() {
+  const user = await requireAdmin()
+  if (!user || !canViewEmployee(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const employees = await prisma.employee.findMany({
+    orderBy: [{ resignDate: 'asc' }, { employeeNumber: 'asc' }],
+  })
+  return NextResponse.json(employees.map(e => serializeEmployee(e, user.role)))
+}
+
+export async function POST(req: NextRequest) {
+  const user = await requireAdmin()
+  if (!user || !canEditEmployee(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const body = await req.json()
+  const parsed = baseSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+  const d = parsed.data
+
+  // 機微フィールドの編集権限チェック
+  const editingSensitive = [
+    d.basicPensionNumber, d.healthInsuranceNumber, d.employmentInsuranceNumber,
+    d.residenceCardNumber, d.payrollBankInfo,
+  ].some(v => v !== undefined && v !== null && v !== '')
+  if (editingSensitive && !canViewSensitiveEmployee(user.role)) {
+    return NextResponse.json({ error: '機微情報の編集権限がありません' }, { status: 403 })
+  }
+
+  const created = await prisma.employee.create({
+    data: {
+      employeeNumber: d.employeeNumber,
+      lastName: d.lastName,
+      firstName: d.firstName,
+      lastNameKana: d.lastNameKana || null,
+      firstNameKana: d.firstNameKana || null,
+      hireDate: d.hireDate ? new Date(d.hireDate) : null,
+      hireType: d.hireType ?? null,
+      employmentType: d.employmentType ?? null,
+      department: d.department || null,
+      jobTitle: d.jobTitle || null,
+      jobCategory: d.jobCategory || null,
+      jobDescription: d.jobDescription || null,
+      resignDate: d.resignDate ? new Date(d.resignDate) : null,
+      resignType: d.resignType ?? null,
+      gender: d.gender ?? null,
+      workEmail: d.workEmail || null,
+      workPhone: d.workPhone || null,
+      dateOfBirth: d.dateOfBirth ? new Date(d.dateOfBirth) : null,
+      address: d.address || null,
+      emergencyContact: d.emergencyContact || null,
+      personalPhone: d.personalPhone || null,
+      basicPensionNumberEnc: encField(d.basicPensionNumber ?? null),
+      healthInsuranceNumberEnc: encField(d.healthInsuranceNumber ?? null),
+      employmentInsuranceNumberEnc: encField(d.employmentInsuranceNumber ?? null),
+      residenceCardNumberEnc: encField(d.residenceCardNumber ?? null),
+      payrollBankInfoEnc: encField(d.payrollBankInfo ?? null),
+      qualifications: d.qualifications || null,
+      resumeDriveUrl: d.resumeDriveUrl || null,
+      businessCardDriveUrl: d.businessCardDriveUrl || null,
+      profilePhotoDriveUrl: d.profilePhotoDriveUrl || null,
+      maritalStatus: d.maritalStatus ?? null,
+    },
+  })
+  return NextResponse.json(serializeEmployee(created, user.role), { status: 201 })
+}

--- a/src/app/api/admin/inventory/[id]/route.ts
+++ b/src/app/api/admin/inventory/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { requireAdmin, canEditInventory, canViewInventory } from '@/lib/admin-auth'
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  purchasePrice: z.number().int().min(0).optional(),
+  sellingPrice: z.number().int().min(0).optional(),
+  stock: z.number().int().min(0).optional(),
+  hasVariants: z.boolean().optional(),
+  supplierUrl: z.string().max(500).nullable().optional(),
+  supplierEmail: z.string().email().nullable().optional().or(z.literal('')),
+  supplierNote: z.string().max(2000).nullable().optional(),
+})
+
+export async function GET(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canViewInventory(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const product = await prisma.product.findUnique({
+    where: { id },
+    include: { variants: { orderBy: { createdAt: 'asc' } } },
+  })
+  if (!product) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(product)
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const body = await req.json()
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+  const data: any = { ...parsed.data }
+  if (data.supplierEmail === '') data.supplierEmail = null
+
+  const updated = await prisma.product.update({
+    where: { id },
+    data,
+    include: { variants: true },
+  })
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  await prisma.product.delete({ where: { id } })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/admin/inventory/[id]/variants/route.ts
+++ b/src/app/api/admin/inventory/[id]/variants/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { requireAdmin, canEditInventory } from '@/lib/admin-auth'
+
+const createSchema = z.object({
+  sizeName: z.string().min(1).max(60),
+  stock: z.number().int().min(0).default(0),
+  sellingPrice: z.number().int().min(0).nullable().optional(),
+})
+
+const updateSchema = z.object({
+  variantId: z.string().min(1),
+  sizeName: z.string().min(1).max(60).optional(),
+  stock: z.number().int().min(0).optional(),
+  sellingPrice: z.number().int().min(0).nullable().optional(),
+})
+
+const deleteSchema = z.object({
+  variantId: z.string().min(1),
+})
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await ctx.params
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message }, { status: 400 })
+
+  const variant = await prisma.productVariant.create({
+    data: { productId: id, sizeName: parsed.data.sizeName, stock: parsed.data.stock, sellingPrice: parsed.data.sellingPrice ?? null },
+  })
+  await prisma.product.update({ where: { id }, data: { hasVariants: true } })
+  return NextResponse.json(variant, { status: 201 })
+}
+
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await ctx.params
+  const body = await req.json()
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message }, { status: 400 })
+
+  const { variantId, ...rest } = parsed.data
+  const existing = await prisma.productVariant.findUnique({ where: { id: variantId } })
+  if (!existing || existing.productId !== id) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const updated = await prisma.productVariant.update({ where: { id: variantId }, data: rest })
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await ctx.params
+  const body = await req.json()
+  const parsed = deleteSchema.safeParse(body)
+  if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message }, { status: 400 })
+
+  const existing = await prisma.productVariant.findUnique({ where: { id: parsed.data.variantId } })
+  if (!existing || existing.productId !== id) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  await prisma.productVariant.delete({ where: { id: parsed.data.variantId } })
+
+  const remaining = await prisma.productVariant.count({ where: { productId: id } })
+  if (remaining === 0) {
+    await prisma.product.update({ where: { id }, data: { hasVariants: false } })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { requireAdmin, canEditInventory, canViewInventory } from '@/lib/admin-auth'
+
+const variantSchema = z.object({
+  sizeName: z.string().min(1).max(60),
+  stock: z.number().int().min(0).default(0),
+  sellingPrice: z.number().int().min(0).nullable().optional(),
+})
+
+const createSchema = z.object({
+  name: z.string().min(1).max(120),
+  purchasePrice: z.number().int().min(0),
+  sellingPrice: z.number().int().min(0),
+  stock: z.number().int().min(0).default(0),
+  hasVariants: z.boolean().default(false),
+  supplierUrl: z.string().max(500).nullable().optional(),
+  supplierEmail: z.string().email().nullable().optional().or(z.literal('')),
+  supplierNote: z.string().max(2000).nullable().optional(),
+  variants: z.array(variantSchema).optional(),
+})
+
+export async function GET() {
+  const user = await requireAdmin()
+  if (!user || !canViewInventory(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const products = await prisma.product.findMany({
+    include: { variants: { orderBy: { createdAt: 'asc' } } },
+    orderBy: { createdAt: 'desc' },
+  })
+  return NextResponse.json(products)
+}
+
+export async function POST(req: NextRequest) {
+  const user = await requireAdmin()
+  if (!user || !canEditInventory(user.role)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await req.json()
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+
+  const { variants, supplierEmail, ...rest } = parsed.data
+  const data: any = { ...rest }
+  if (supplierEmail === '' || supplierEmail === undefined) data.supplierEmail = null
+  else data.supplierEmail = supplierEmail
+
+  const product = await prisma.product.create({
+    data: {
+      ...data,
+      variants: variants && variants.length > 0
+        ? { create: variants.map(v => ({ sizeName: v.sizeName, stock: v.stock, sellingPrice: v.sellingPrice ?? null })) }
+        : undefined,
+    },
+    include: { variants: true },
+  })
+  return NextResponse.json(product, { status: 201 })
+}

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -5,7 +5,16 @@ import { useSession, signOut } from 'next-auth/react'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 
-const navItems = [
+type AdminRole = 'admin' | 'superadmin' | 'hr'
+
+type NavItem = {
+  href: string
+  label: string
+  icon: React.ReactNode
+  roles?: AdminRole[]  // undefined = 全 admin role 共通
+}
+
+const navItems: NavItem[] = [
   {
     href: '/admin/dashboard',
     label: 'ダッシュボード',
@@ -142,6 +151,26 @@ const navItems = [
       </svg>
     ),
   },
+  {
+    href: '/admin/inventory',
+    label: '備品管理',
+    roles: ['superadmin', 'admin', 'hr'],
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+      </svg>
+    ),
+  },
+  {
+    href: '/admin/employees',
+    label: '社員情報',
+    roles: ['superadmin', 'hr', 'admin'],
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+  },
 ]
 
 export default function NavigationDrawer() {
@@ -180,7 +209,7 @@ export default function NavigationDrawer() {
 
       {/* Nav items */}
       <nav className="flex-1 px-3 py-2 space-y-0.5 overflow-y-auto thin-scrollbar">
-        {navItems.map(item => {
+        {navItems.filter(item => !item.roles || item.roles.includes(user?.role as AdminRole)).map(item => {
           const active = pathname === item.href || pathname.startsWith(item.href + '/')
           return (
             <Link

--- a/src/components/admin/EmployeeForm.tsx
+++ b/src/components/admin/EmployeeForm.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { HIRE_TYPES, EMPLOYMENT_TYPES, RESIGN_TYPES, GENDERS, MARITAL_STATUSES } from '@/lib/employee-utils'
+
+export type EmployeeFormState = {
+  employeeNumber: string
+  lastName: string
+  firstName: string
+  lastNameKana: string
+  firstNameKana: string
+  hireDate: string
+  hireType: string
+  employmentType: string
+  department: string
+  jobTitle: string
+  jobCategory: string
+  jobDescription: string
+  resignDate: string
+  resignType: string
+  gender: string
+  workEmail: string
+  workPhone: string
+  dateOfBirth: string
+  address: string
+  emergencyContact: string
+  personalPhone: string
+  basicPensionNumber: string
+  healthInsuranceNumber: string
+  employmentInsuranceNumber: string
+  residenceCardNumber: string
+  payrollBankInfo: string
+  qualifications: string
+  resumeDriveUrl: string
+  businessCardDriveUrl: string
+  profilePhotoDriveUrl: string
+  maritalStatus: string
+}
+
+export const EMPTY_EMPLOYEE: EmployeeFormState = {
+  employeeNumber: '',
+  lastName: '',
+  firstName: '',
+  lastNameKana: '',
+  firstNameKana: '',
+  hireDate: '',
+  hireType: '',
+  employmentType: '',
+  department: '',
+  jobTitle: '',
+  jobCategory: '',
+  jobDescription: '',
+  resignDate: '',
+  resignType: '',
+  gender: '',
+  workEmail: '',
+  workPhone: '',
+  dateOfBirth: '',
+  address: '',
+  emergencyContact: '',
+  personalPhone: '',
+  basicPensionNumber: '',
+  healthInsuranceNumber: '',
+  employmentInsuranceNumber: '',
+  residenceCardNumber: '',
+  payrollBankInfo: '',
+  qualifications: '',
+  resumeDriveUrl: '',
+  businessCardDriveUrl: '',
+  profilePhotoDriveUrl: '',
+  maritalStatus: '',
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 6,
+  border: '1px solid var(--md-sys-color-outline-variant)',
+  background: 'var(--md-sys-color-surface)',
+  color: 'var(--md-sys-color-on-surface)',
+  fontSize: 14,
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const sectionStyle: React.CSSProperties = {
+  background: 'var(--md-sys-color-surface-container-low)',
+  borderRadius: 12,
+  padding: 20,
+  marginBottom: 16,
+  border: '1px solid var(--md-sys-color-outline-variant)',
+}
+
+function Field({ label, children, span2 }: { label: string; children: React.ReactNode; span2?: boolean }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13, gridColumn: span2 ? '1 / -1' : undefined }}>
+      <span style={{ color: 'var(--md-sys-color-on-surface-variant)' }}>{label}</span>
+      {children}
+    </label>
+  )
+}
+
+type Props = {
+  value: EmployeeFormState
+  onChange: (next: EmployeeFormState) => void
+  showSensitive: boolean
+  disabled?: boolean
+}
+
+export default function EmployeeForm({ value, onChange, showSensitive, disabled = false }: Props) {
+  const set = <K extends keyof EmployeeFormState>(k: K, v: string) => onChange({ ...value, [k]: v })
+  const grid = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 } as React.CSSProperties
+
+  return (
+    <>
+      <section style={sectionStyle}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>基本情報</h2>
+        <div style={grid}>
+          <Field label="従業員番号 *"><input value={value.employeeNumber} onChange={e => set('employeeNumber', e.target.value)} style={inputStyle} disabled={disabled} placeholder="028" /></Field>
+          <div />
+          <Field label="苗字 *"><input value={value.lastName} onChange={e => set('lastName', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="名前 *"><input value={value.firstName} onChange={e => set('firstName', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="苗字（フリガナ）"><input value={value.lastNameKana} onChange={e => set('lastNameKana', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="名前（フリガナ）"><input value={value.firstNameKana} onChange={e => set('firstNameKana', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="性別">
+            <select value={value.gender} onChange={e => set('gender', e.target.value)} style={inputStyle} disabled={disabled}>
+              <option value="">未選択</option>
+              {GENDERS.map(g => <option key={g} value={g}>{g}</option>)}
+            </select>
+          </Field>
+          <Field label="未婚 / 既婚">
+            <select value={value.maritalStatus} onChange={e => set('maritalStatus', e.target.value)} style={inputStyle} disabled={disabled}>
+              <option value="">未選択</option>
+              <option value="single">未婚</option>
+              <option value="married">既婚</option>
+            </select>
+          </Field>
+        </div>
+      </section>
+
+      <section style={sectionStyle}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>雇用情報</h2>
+        <div style={grid}>
+          <Field label="入社年月日"><input type="date" value={value.hireDate} onChange={e => set('hireDate', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="入社区分">
+            <select value={value.hireType} onChange={e => set('hireType', e.target.value)} style={inputStyle} disabled={disabled}>
+              <option value="">未選択</option>
+              {HIRE_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </Field>
+          <Field label="雇用形態">
+            <select value={value.employmentType} onChange={e => set('employmentType', e.target.value)} style={inputStyle} disabled={disabled}>
+              <option value="">未選択</option>
+              {EMPLOYMENT_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </Field>
+          <Field label="所属部署"><input value={value.department} onChange={e => set('department', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="肩書き"><input value={value.jobTitle} onChange={e => set('jobTitle', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="職種"><input value={value.jobCategory} onChange={e => set('jobCategory', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="職務内容" span2><textarea value={value.jobDescription} onChange={e => set('jobDescription', e.target.value)} style={{ ...inputStyle, minHeight: 60 }} disabled={disabled} /></Field>
+          <Field label="退社年月日"><input type="date" value={value.resignDate} onChange={e => set('resignDate', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="退職区分">
+            <select value={value.resignType} onChange={e => set('resignType', e.target.value)} style={inputStyle} disabled={disabled}>
+              <option value="">未選択</option>
+              {RESIGN_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </Field>
+          <Field label="社用メールアドレス"><input type="email" value={value.workEmail} onChange={e => set('workEmail', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="社用電話番号"><input value={value.workPhone} onChange={e => set('workPhone', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+          <Field label="保有資格" span2><textarea value={value.qualifications} onChange={e => set('qualifications', e.target.value)} style={{ ...inputStyle, minHeight: 60 }} placeholder="日商簿記2級, TOEIC 800 など" disabled={disabled} /></Field>
+        </div>
+      </section>
+
+      {showSensitive && (
+        <>
+          <section style={sectionStyle}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>個人情報</h2>
+            <div style={grid}>
+              <Field label="生年月日"><input type="date" value={value.dateOfBirth} onChange={e => set('dateOfBirth', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="個人電話番号"><input value={value.personalPhone} onChange={e => set('personalPhone', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="住所" span2><textarea value={value.address} onChange={e => set('address', e.target.value)} style={{ ...inputStyle, minHeight: 60 }} disabled={disabled} /></Field>
+              <Field label="緊急連絡先" span2><textarea value={value.emergencyContact} onChange={e => set('emergencyContact', e.target.value)} style={{ ...inputStyle, minHeight: 60 }} placeholder="続柄・氏名・電話番号" disabled={disabled} /></Field>
+            </div>
+          </section>
+
+          <section style={{ ...sectionStyle, borderColor: 'rgba(211, 47, 47, 0.4)' }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 4px' }}>機微情報（暗号化保存）</h2>
+            <p style={{ fontSize: 12, color: 'var(--md-sys-color-on-surface-variant)', margin: '0 0 12px' }}>
+              これらのフィールドは AES-256-GCM で暗号化されて保存されます。superadmin / hr のみ閲覧可能。
+            </p>
+            <div style={grid}>
+              <Field label="基礎年金番号"><input value={value.basicPensionNumber} onChange={e => set('basicPensionNumber', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="健康保険番号"><input value={value.healthInsuranceNumber} onChange={e => set('healthInsuranceNumber', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="雇用保険番号"><input value={value.employmentInsuranceNumber} onChange={e => set('employmentInsuranceNumber', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="在留カード番号"><input value={value.residenceCardNumber} onChange={e => set('residenceCardNumber', e.target.value)} style={inputStyle} disabled={disabled} /></Field>
+              <Field label="給与振込先情報" span2><textarea value={value.payrollBankInfo} onChange={e => set('payrollBankInfo', e.target.value)} style={{ ...inputStyle, minHeight: 80 }} placeholder="銀行名 / 支店名 / 口座種別 / 口座番号 / 名義" disabled={disabled} /></Field>
+            </div>
+          </section>
+
+          <section style={sectionStyle}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>添付ファイル（Google Drive リンク）</h2>
+            <div style={grid}>
+              <Field label="履歴書 Drive リンク" span2><input value={value.resumeDriveUrl} onChange={e => set('resumeDriveUrl', e.target.value)} style={inputStyle} placeholder="https://drive.google.com/..." disabled={disabled} /></Field>
+              <Field label="名刺データ Drive リンク" span2><input value={value.businessCardDriveUrl} onChange={e => set('businessCardDriveUrl', e.target.value)} style={inputStyle} placeholder="https://drive.google.com/..." disabled={disabled} /></Field>
+              <Field label="プロフィール写真 Drive リンク" span2><input value={value.profilePhotoDriveUrl} onChange={e => set('profilePhotoDriveUrl', e.target.value)} style={inputStyle} placeholder="https://drive.google.com/..." disabled={disabled} /></Field>
+            </div>
+          </section>
+        </>
+      )}
+    </>
+  )
+}
+
+export function buildEmployeePayload(form: EmployeeFormState, includeSensitive: boolean): Record<string, any> {
+  const toNullable = (v: string) => (v.trim() === '' ? null : v.trim())
+  const base: Record<string, any> = {
+    employeeNumber: form.employeeNumber.trim(),
+    lastName: form.lastName.trim(),
+    firstName: form.firstName.trim(),
+    lastNameKana: toNullable(form.lastNameKana),
+    firstNameKana: toNullable(form.firstNameKana),
+    hireDate: toNullable(form.hireDate),
+    hireType: toNullable(form.hireType),
+    employmentType: toNullable(form.employmentType),
+    department: toNullable(form.department),
+    jobTitle: toNullable(form.jobTitle),
+    jobCategory: toNullable(form.jobCategory),
+    jobDescription: toNullable(form.jobDescription),
+    resignDate: toNullable(form.resignDate),
+    resignType: toNullable(form.resignType),
+    gender: toNullable(form.gender),
+    workEmail: toNullable(form.workEmail),
+    workPhone: toNullable(form.workPhone),
+    qualifications: toNullable(form.qualifications),
+    maritalStatus: toNullable(form.maritalStatus),
+  }
+  if (includeSensitive) {
+    base.dateOfBirth = toNullable(form.dateOfBirth)
+    base.address = toNullable(form.address)
+    base.emergencyContact = toNullable(form.emergencyContact)
+    base.personalPhone = toNullable(form.personalPhone)
+    base.basicPensionNumber = toNullable(form.basicPensionNumber)
+    base.healthInsuranceNumber = toNullable(form.healthInsuranceNumber)
+    base.employmentInsuranceNumber = toNullable(form.employmentInsuranceNumber)
+    base.residenceCardNumber = toNullable(form.residenceCardNumber)
+    base.payrollBankInfo = toNullable(form.payrollBankInfo)
+    base.resumeDriveUrl = toNullable(form.resumeDriveUrl)
+    base.businessCardDriveUrl = toNullable(form.businessCardDriveUrl)
+    base.profilePhotoDriveUrl = toNullable(form.profilePhotoDriveUrl)
+  }
+  return base
+}
+
+export function fromEmployeeApi(api: any): EmployeeFormState {
+  const fmtDate = (v: any) => (v ? String(v).slice(0, 10) : '')
+  return {
+    ...EMPTY_EMPLOYEE,
+    employeeNumber: api.employeeNumber ?? '',
+    lastName: api.lastName ?? '',
+    firstName: api.firstName ?? '',
+    lastNameKana: api.lastNameKana ?? '',
+    firstNameKana: api.firstNameKana ?? '',
+    hireDate: fmtDate(api.hireDate),
+    hireType: api.hireType ?? '',
+    employmentType: api.employmentType ?? '',
+    department: api.department ?? '',
+    jobTitle: api.jobTitle ?? '',
+    jobCategory: api.jobCategory ?? '',
+    jobDescription: api.jobDescription ?? '',
+    resignDate: fmtDate(api.resignDate),
+    resignType: api.resignType ?? '',
+    gender: api.gender ?? '',
+    workEmail: api.workEmail ?? '',
+    workPhone: api.workPhone ?? '',
+    dateOfBirth: fmtDate(api.dateOfBirth),
+    address: api.address ?? '',
+    emergencyContact: api.emergencyContact ?? '',
+    personalPhone: api.personalPhone ?? '',
+    basicPensionNumber: api.basicPensionNumber ?? '',
+    healthInsuranceNumber: api.healthInsuranceNumber ?? '',
+    employmentInsuranceNumber: api.employmentInsuranceNumber ?? '',
+    residenceCardNumber: api.residenceCardNumber ?? '',
+    payrollBankInfo: api.payrollBankInfo ?? '',
+    qualifications: api.qualifications ?? '',
+    resumeDriveUrl: api.resumeDriveUrl ?? '',
+    businessCardDriveUrl: api.businessCardDriveUrl ?? '',
+    profilePhotoDriveUrl: api.profilePhotoDriveUrl ?? '',
+    maritalStatus: api.maritalStatus ?? '',
+  }
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,62 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+export type AdminRole = 'admin' | 'superadmin' | 'hr'
+
+export const ADMIN_ROLES: AdminRole[] = ['admin', 'superadmin', 'hr']
+
+export type AdminUser = {
+  id: string
+  email: string
+  name?: string | null
+  role: AdminRole
+  avatar?: string | null
+}
+
+function isAdminRole(value: unknown): value is AdminRole {
+  return value === 'admin' || value === 'superadmin' || value === 'hr'
+}
+
+export async function getAdminUser(): Promise<AdminUser | null> {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as any
+  if (!user || !isAdminRole(user.role)) return null
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name ?? null,
+    role: user.role,
+    avatar: user.avatar ?? null,
+  }
+}
+
+export async function requireAdmin(): Promise<AdminUser | null> {
+  return getAdminUser()
+}
+
+export async function requireRole(allowed: AdminRole[]): Promise<AdminUser | null> {
+  const user = await getAdminUser()
+  if (!user) return null
+  if (!allowed.includes(user.role)) return null
+  return user
+}
+
+export function canViewSensitiveEmployee(role: AdminRole): boolean {
+  return role === 'superadmin' || role === 'hr'
+}
+
+export function canEditEmployee(role: AdminRole): boolean {
+  return role === 'superadmin' || role === 'hr'
+}
+
+export function canViewEmployee(role: AdminRole): boolean {
+  return role === 'superadmin' || role === 'hr' || role === 'admin'
+}
+
+export function canEditInventory(role: AdminRole): boolean {
+  return role === 'superadmin' || role === 'admin'
+}
+
+export function canViewInventory(role: AdminRole): boolean {
+  return role === 'superadmin' || role === 'admin' || role === 'hr'
+}

--- a/src/lib/employee-utils.ts
+++ b/src/lib/employee-utils.ts
@@ -1,0 +1,103 @@
+import { encrypt, decrypt } from '@/lib/encrypt'
+import type { AdminRole } from '@/lib/admin-auth'
+import { canViewSensitiveEmployee } from '@/lib/admin-auth'
+
+export const HIRE_TYPES = ['新卒', '中途', '出向', 'その他'] as const
+export const EMPLOYMENT_TYPES = ['正社員', '契約社員', 'パート', 'アルバイト', '業務委託', '派遣', 'その他'] as const
+export const RESIGN_TYPES = ['自己都合', '会社都合', '定年', '契約満了', 'その他'] as const
+export const GENDERS = ['男性', '女性', 'その他', '未回答'] as const
+export const MARITAL_STATUSES = ['single', 'married'] as const
+
+export const SENSITIVE_FIELDS = [
+  'basicPensionNumber',
+  'healthInsuranceNumber',
+  'employmentInsuranceNumber',
+  'residenceCardNumber',
+  'payrollBankInfo',
+  'personalPhone',
+  'address',
+  'emergencyContact',
+  'dateOfBirth',
+  'resumeDriveUrl',
+] as const
+
+export type EncryptedFieldKey =
+  | 'basicPensionNumber'
+  | 'healthInsuranceNumber'
+  | 'employmentInsuranceNumber'
+  | 'residenceCardNumber'
+  | 'payrollBankInfo'
+
+export const ENCRYPTED_FIELD_KEYS: EncryptedFieldKey[] = [
+  'basicPensionNumber',
+  'healthInsuranceNumber',
+  'employmentInsuranceNumber',
+  'residenceCardNumber',
+  'payrollBankInfo',
+]
+
+export function encField(plain: string | null | undefined): string | null {
+  if (plain === null || plain === undefined || plain === '') return null
+  return encrypt(plain)
+}
+
+export function decField(cipher: string | null | undefined): string | null {
+  if (!cipher) return null
+  return decrypt(cipher)
+}
+
+type EmployeeRow = Record<string, any>
+
+/**
+ * DB row → API response。role に応じて機微フィールドをマスク。
+ */
+export function serializeEmployee(row: EmployeeRow, role: AdminRole) {
+  const base = {
+    id: row.id,
+    employeeNumber: row.employeeNumber,
+    lastName: row.lastName,
+    firstName: row.firstName,
+    lastNameKana: row.lastNameKana,
+    firstNameKana: row.firstNameKana,
+    hireDate: row.hireDate,
+    hireType: row.hireType,
+    employmentType: row.employmentType,
+    department: row.department,
+    jobTitle: row.jobTitle,
+    jobCategory: row.jobCategory,
+    jobDescription: row.jobDescription,
+    resignDate: row.resignDate,
+    resignType: row.resignType,
+    gender: row.gender,
+    workEmail: row.workEmail,
+    workPhone: row.workPhone,
+    qualifications: row.qualifications,
+    businessCardDriveUrl: row.businessCardDriveUrl,
+    profilePhotoDriveUrl: row.profilePhotoDriveUrl,
+    maritalStatus: row.maritalStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+
+  if (!canViewSensitiveEmployee(role)) {
+    return base
+  }
+
+  return {
+    ...base,
+    dateOfBirth: row.dateOfBirth,
+    address: row.address,
+    emergencyContact: row.emergencyContact,
+    personalPhone: row.personalPhone,
+    resumeDriveUrl: row.resumeDriveUrl,
+    basicPensionNumber: decField(row.basicPensionNumberEnc),
+    healthInsuranceNumber: decField(row.healthInsuranceNumberEnc),
+    employmentInsuranceNumber: decField(row.employmentInsuranceNumberEnc),
+    residenceCardNumber: decField(row.residenceCardNumberEnc),
+    payrollBankInfo: decField(row.payrollBankInfoEnc),
+  }
+}
+
+export function fullName(row: { lastName: string; firstName: string }) {
+  return `${row.lastName} ${row.firstName}`
+}


### PR DESCRIPTION
## 概要

管理ポータルに2つの新機能を追加し、機微情報保護のためロールを3階層に拡張。

### 1. 備品管理 (`/admin/inventory`)
- 商品名・仕入れ価格・販売価格・在庫数・発注先(URL/メール)を管理
- 商品ごとにサイズバリアント+各サイズで在庫を保持

### 2. 社員情報 (`/admin/employees`)
- 基本情報・雇用情報・個人情報・機微情報・添付ファイルを一元管理
- 履歴書/名刺/プロフィール写真は GoogleDrive リンクで保管
- 社員ID は cuid 自動生成、従業員番号は手動入力

### 3. ロール拡張
- `admin` / `superadmin` / `hr` の3階層
- 機微情報(年金番号/保険番号/在留カード番号/給与振込先) は `superadmin`/`hr` のみ閲覧・編集可
- API レスポンスで role に応じて機微フィールドをマスク
- `admin` ロールは社員情報の基本フィールドのみ閲覧可・編集不可

### 4. 暗号化
- 機微情報は AES-256-GCM (`@/lib/encrypt`) で DB 暗号化
- SMTP パスワードと同じ仕組み・鍵 (`ENCRYPTION_KEY`)

## 主要ファイル
- `prisma/schema.prisma` — `Product` / `ProductVariant` / `Employee` 追加
- `src/lib/admin-auth.ts` — 共通認可ヘルパ (新規)
- `src/lib/employee-utils.ts` — enum + `serializeEmployee(row, role)` で role別マスク
- `src/components/admin/EmployeeForm.tsx` — 新規/編集共通フォーム
- 既存 `requireAdmin()` を持つ API は無変更 (リグレッション回避)

## デプロイ手順
1. **Vercel の `ENCRYPTION_KEY` が設定されていることを確認**
2. このPRをマージ → Vercel自動デプロイ
3. `npx prisma migrate deploy` で本番DBに新規テーブルを作成
   - 破壊的変更なし: `Product` / `ProductVariant` / `Employee` の CREATE TABLE のみ
4. Prisma Studio などで自分のAdminレコードの `role` を `superadmin` に手動更新
5. 動作確認

## Test plan
- [ ] `superadmin` で備品の CRUD・サイズバリアント追加削除
- [ ] `superadmin` で社員作成→機微フィールドが DB で ciphertext になっていること(Prisma Studio)
- [ ] `hr` で社員 CRUD ができ、備品は閲覧のみ
- [ ] `admin` で社員一覧の機微フィールドが API レスポンスに含まれないこと(DevTools Network)
- [ ] ナビメニューが role 別に正しく表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)