### PR TITLE
備品管理に商品画像のアップロード機能を追加

### DIFF
--- a/prisma/migrations/20260510090000_add_inventory_and_employee/migration.sql
+++ b/prisma/migrations/20260510090000_add_inventory_and_employee/migration.sql
@@ -1,0 +1,79 @@
+-- Product テーブル
+CREATE TABLE "Product" (
+  "id"            TEXT NOT NULL,
+  "name"          TEXT NOT NULL,
+  "purchasePrice" INTEGER NOT NULL,
+  "sellingPrice"  INTEGER NOT NULL,
+  "stock"         INTEGER NOT NULL DEFAULT 0,
+  "hasVariants"   BOOLEAN NOT NULL DEFAULT false,
+  "imageUrl"      TEXT,
+  "supplierUrl"   TEXT,
+  "supplierEmail" TEXT,
+  "supplierNote"  TEXT,
+  "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"     TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- ProductVariant テーブル
+CREATE TABLE "ProductVariant" (
+  "id"           TEXT NOT NULL,
+  "productId"    TEXT NOT NULL,
+  "sizeName"     TEXT NOT NULL,
+  "stock"        INTEGER NOT NULL DEFAULT 0,
+  "sellingPrice" INTEGER,
+  "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"    TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "ProductVariant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProductVariant_productId_idx" ON "ProductVariant"("productId");
+
+ALTER TABLE "ProductVariant" ADD CONSTRAINT "ProductVariant_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Employee テーブル
+CREATE TABLE "Employee" (
+  "id"                            TEXT NOT NULL,
+  "employeeNumber"                TEXT NOT NULL,
+  "lastName"                      TEXT NOT NULL,
+  "firstName"                     TEXT NOT NULL,
+  "lastNameKana"                  TEXT,
+  "firstNameKana"                 TEXT,
+  "hireDate"                      TIMESTAMP(3),
+  "hireType"                      TEXT,
+  "employmentType"                TEXT,
+  "department"                    TEXT,
+  "jobTitle"                      TEXT,
+  "jobCategory"                   TEXT,
+  "jobDescription"                TEXT,
+  "resignDate"                    TIMESTAMP(3),
+  "resignType"                    TEXT,
+  "gender"                        TEXT,
+  "workEmail"                     TEXT,
+  "workPhone"                     TEXT,
+  "dateOfBirth"                   TIMESTAMP(3),
+  "address"                       TEXT,
+  "emergencyContact"              TEXT,
+  "personalPhone"                 TEXT,
+  "basicPensionNumberEnc"         TEXT,
+  "healthInsuranceNumberEnc"      TEXT,
+  "employmentInsuranceNumberEnc"  TEXT,
+  "residenceCardNumberEnc"        TEXT,
+  "payrollBankInfoEnc"            TEXT,
+  "qualifications"                TEXT,
+  "resumeDriveUrl"                TEXT,
+  "businessCardDriveUrl"          TEXT,
+  "profilePhotoDriveUrl"          TEXT,
+  "maritalStatus"                 TEXT,
+  "createdAt"                     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"                     TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "Employee_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Employee_employeeNumber_key" ON "Employee"("employeeNumber");
+CREATE INDEX "Employee_department_idx"           ON "Employee"("department");
+CREATE INDEX "Employee_resignDate_idx"           ON "Employee"("resignDate");

--- a/prisma/migrations/20260510090000_add_product_image_url/migration.sql
+++ b/prisma/migrations/20260510090000_add_product_image_url/migration.sql
@@ -1,2 +1,0 @@
--- Product に imageUrl カラムを追加
-ALTER TABLE "Product" ADD COLUMN "imageUrl" TEXT;

--- a/prisma/migrations/20260510090000_add_product_image_url/migration.sql
+++ b/prisma/migrations/20260510090000_add_product_image_url/migration.sql
@@ -1,0 +1,2 @@
+-- Product に imageUrl カラムを追加
+ALTER TABLE "Product" ADD COLUMN "imageUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -791,6 +791,7 @@ model Product {
   sellingPrice  Int              // 販売価格（円）
   stock         Int              @default(0)  // hasVariants=false 時の在庫
   hasVariants   Boolean          @default(false)
+  imageUrl      String?          @db.Text  // 商品画像URL（Vercel Blob）
   supplierUrl   String?          @db.Text
   supplierEmail String?
   supplierNote  String?          @db.Text

--- a/src/app/(admin)/admin/inventory/[id]/page.tsx
+++ b/src/app/(admin)/admin/inventory/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, use as usePromise } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import ProductImageUploader from '@/components/admin/ProductImageUploader'
 
 type Variant = {
   id: string
@@ -19,6 +20,7 @@ type Product = {
   sellingPrice: number
   stock: number
   hasVariants: boolean
+  imageUrl: string | null
   supplierUrl: string | null
   supplierEmail: string | null
   supplierNote: string | null
@@ -63,6 +65,7 @@ export default function InventoryDetailPage({ params }: { params: Promise<{ id: 
   const [purchasePrice, setPurchasePrice] = useState('0')
   const [sellingPrice, setSellingPrice] = useState('0')
   const [stock, setStock] = useState('0')
+  const [imageUrl, setImageUrl] = useState('')
   const [supplierUrl, setSupplierUrl] = useState('')
   const [supplierEmail, setSupplierEmail] = useState('')
   const [supplierNote, setSupplierNote] = useState('')
@@ -86,6 +89,7 @@ export default function InventoryDetailPage({ params }: { params: Promise<{ id: 
           setPurchasePrice(String(p.purchasePrice))
           setSellingPrice(String(p.sellingPrice))
           setStock(String(p.stock))
+          setImageUrl(p.imageUrl ?? '')
           setSupplierUrl(p.supplierUrl ?? '')
           setSupplierEmail(p.supplierEmail ?? '')
           setSupplierNote(p.supplierNote ?? '')
@@ -116,6 +120,7 @@ export default function InventoryDetailPage({ params }: { params: Promise<{ id: 
           purchasePrice: Number(purchasePrice),
           sellingPrice: Number(sellingPrice),
           stock: Number(stock),
+          imageUrl: imageUrl || null,
           supplierUrl: supplierUrl || null,
           supplierEmail: supplierEmail || null,
           supplierNote: supplierNote || null,
@@ -200,6 +205,16 @@ export default function InventoryDetailPage({ params }: { params: Promise<{ id: 
 
       <section style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, padding: 20, marginBottom: 20, border: '1px solid var(--md-sys-color-outline-variant)' }}>
         <h2 style={{ fontSize: 16, fontWeight: 700, margin: '0 0 12px' }}>基本情報</h2>
+        <div style={{ marginBottom: 16 }}>
+          <Field label="商品画像">
+            <ProductImageUploader
+              value={imageUrl}
+              onChange={setImageUrl}
+              onError={text => flash('error', text)}
+              disabled={!canEdit}
+            />
+          </Field>
+        </div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
           <Field label="商品名"><input value={name} onChange={e => setName(e.target.value)} style={inputStyle} disabled={!canEdit} /></Field>
           <Field label="在庫数（バリアントなし時）"><input type="number" value={stock} onChange={e => setStock(e.target.value)} style={inputStyle} disabled={!canEdit || product.hasVariants} /></Field>

--- a/src/app/(admin)/admin/inventory/page.tsx
+++ b/src/app/(admin)/admin/inventory/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import LoadingSpinner from '@/components/LoadingSpinner'
+import ProductImageUploader from '@/components/admin/ProductImageUploader'
 
 type Variant = {
   id: string
@@ -19,6 +20,7 @@ type Product = {
   sellingPrice: number
   stock: number
   hasVariants: boolean
+  imageUrl: string | null
   supplierUrl: string | null
   supplierEmail: string | null
   supplierNote: string | null
@@ -31,6 +33,7 @@ type FormState = {
   purchasePrice: string
   sellingPrice: string
   stock: string
+  imageUrl: string
   supplierUrl: string
   supplierEmail: string
   supplierNote: string
@@ -41,6 +44,7 @@ const EMPTY: FormState = {
   purchasePrice: '',
   sellingPrice: '',
   stock: '0',
+  imageUrl: '',
   supplierUrl: '',
   supplierEmail: '',
   supplierNote: '',
@@ -113,6 +117,7 @@ export default function InventoryListPage() {
           purchasePrice,
           sellingPrice,
           stock,
+          imageUrl: form.imageUrl.trim() || null,
           supplierUrl: form.supplierUrl.trim() || null,
           supplierEmail: form.supplierEmail.trim() || null,
           supplierNote: form.supplierNote.trim() || null,
@@ -172,6 +177,7 @@ export default function InventoryListPage() {
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
           <thead>
             <tr style={{ background: 'var(--md-sys-color-surface-container)', textAlign: 'left' }}>
+              <th style={{ padding: '12px 16px', fontWeight: 600, width: 64 }}></th>
               <th style={{ padding: '12px 16px', fontWeight: 600 }}>商品名</th>
               <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>仕入れ価格</th>
               <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>販売価格</th>
@@ -184,7 +190,7 @@ export default function InventoryListPage() {
           <tbody>
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={7} style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--md-sys-color-on-surface-variant)' }}>
+                <td colSpan={8} style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--md-sys-color-on-surface-variant)' }}>
                   商品が登録されていません
                 </td>
               </tr>
@@ -195,6 +201,11 @@ export default function InventoryListPage() {
                 : p.stock
               return (
                 <tr key={p.id} style={{ borderTop: '1px solid var(--md-sys-color-outline-variant)' }}>
+                  <td style={{ padding: '8px 16px' }}>
+                    {p.imageUrl
+                      ? <img src={p.imageUrl} alt="" style={{ width: 48, height: 48, objectFit: 'cover', borderRadius: 6, border: '1px solid var(--md-sys-color-outline-variant)' }} />
+                      : <div style={{ width: 48, height: 48, borderRadius: 6, background: 'var(--md-sys-color-surface-container)', border: '1px solid var(--md-sys-color-outline-variant)' }} />}
+                  </td>
                   <td style={{ padding: '12px 16px', fontWeight: 600 }}>{p.name}</td>
                   <td style={{ padding: '12px 16px', textAlign: 'right' }}>¥{p.purchasePrice.toLocaleString()}</td>
                   <td style={{ padding: '12px 16px', textAlign: 'right' }}>¥{p.sellingPrice.toLocaleString()}</td>
@@ -236,6 +247,13 @@ export default function InventoryListPage() {
             <h2 style={{ margin: '0 0 16px', fontSize: 18, fontWeight: 700 }}>商品を追加</h2>
             {error && <p style={{ color: 'var(--md-sys-color-error)', fontSize: 13, marginBottom: 12 }}>{error}</p>}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <Field label="商品画像">
+                <ProductImageUploader
+                  value={form.imageUrl}
+                  onChange={url => setForm({ ...form, imageUrl: url })}
+                  onError={msg => setError(msg)}
+                />
+              </Field>
               <Field label="商品名 *">
                 <input value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} style={inputStyle} />
               </Field>

--- a/src/app/api/admin/inventory/[id]/route.ts
+++ b/src/app/api/admin/inventory/[id]/route.ts
@@ -9,6 +9,7 @@ const updateSchema = z.object({
   sellingPrice: z.number().int().min(0).optional(),
   stock: z.number().int().min(0).optional(),
   hasVariants: z.boolean().optional(),
+  imageUrl: z.string().max(1000).nullable().optional(),
   supplierUrl: z.string().max(500).nullable().optional(),
   supplierEmail: z.string().email().nullable().optional().or(z.literal('')),
   supplierNote: z.string().max(2000).nullable().optional(),

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -15,6 +15,7 @@ const createSchema = z.object({
   sellingPrice: z.number().int().min(0),
   stock: z.number().int().min(0).default(0),
   hasVariants: z.boolean().default(false),
+  imageUrl: z.string().max(1000).nullable().optional(),
   supplierUrl: z.string().max(500).nullable().optional(),
   supplierEmail: z.string().email().nullable().optional().or(z.literal('')),
   supplierNote: z.string().max(2000).nullable().optional(),

--- a/src/components/admin/ProductImageUploader.tsx
+++ b/src/components/admin/ProductImageUploader.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+type Props = {
+  value: string
+  onChange: (url: string) => void
+  onError?: (msg: string) => void
+  disabled?: boolean
+}
+
+export default function ProductImageUploader({ value, onChange, onError, disabled = false }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+
+  async function handleFile(file: File) {
+    if (!file.type.startsWith('image/')) {
+      onError?.('画像ファイルのみアップロードできます')
+      return
+    }
+    setUploading(true)
+    try {
+      const fd = new FormData()
+      fd.append('file', file)
+      const res = await fetch('/api/upload', { method: 'POST', body: fd })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok || !data.url) {
+        onError?.(data.error ?? 'アップロードに失敗しました')
+        return
+      }
+      onChange(data.url)
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div
+        style={{
+          width: 88,
+          height: 88,
+          borderRadius: 8,
+          border: '1px dashed var(--md-sys-color-outline-variant)',
+          background: 'var(--md-sys-color-surface)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          flexShrink: 0,
+        }}
+      >
+        {value
+          ? <img src={value} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+          : <span style={{ fontSize: 11, color: 'var(--md-sys-color-on-surface-variant)' }}>未設定</span>}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={e => {
+            const f = e.target.files?.[0]
+            if (f) handleFile(f)
+          }}
+          disabled={disabled || uploading}
+        />
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled || uploading}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 6,
+            background: 'transparent',
+            color: 'var(--md-sys-color-primary)',
+            border: '1px solid var(--md-sys-color-outline)',
+            fontSize: 13,
+            cursor: disabled || uploading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {uploading ? 'アップロード中…' : value ? '画像を変更' : '画像を選択'}
+        </button>
+        {value && !disabled && (
+          <button
+            type="button"
+            onClick={() => onChange('')}
+            disabled={uploading}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 6,
+              background: 'transparent',
+              color: 'var(--md-sys-color-error)',
+              border: 'none',
+              fontSize: 12,
+              cursor: 'pointer',
+              textAlign: 'left',
+            }}
+          >
+            画像を削除
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要

備品管理の商品に画像をアップロードできるようにする。

- `Product.imageUrl` カラム追加（Vercel Blob URL を保存）
- 商品追加モーダルと詳細ページに `ProductImageUploader` を追加
- 一覧テーブルに 48px サムネイル列を追加
- 既存の `/api/upload` エンドポイント（管理者認証付き、10MB制限、画像のみ）を流用

## 主要ファイル
- `prisma/schema.prisma` — `Product.imageUrl String? @db.Text`
- `prisma/migrations/20260510090000_add_product_image_url/migration.sql`
- `src/components/admin/ProductImageUploader.tsx` — 再利用可能なアップローダー
- `src/app/(admin)/admin/inventory/page.tsx` — モーダル+一覧
- `src/app/(admin)/admin/inventory/[id]/page.tsx` — 詳細
- `src/app/api/admin/inventory/route.ts`, `[id]/route.ts` — Zod スキーマに `imageUrl` 追加

## デプロイ手順
1. このPRをマージ
2. Vercel デプロイ完了後、`npx prisma migrate deploy` で `ALTER TABLE Product ADD COLUMN imageUrl TEXT` を適用

## Test plan
- [ ] 商品追加モーダルで画像をアップロード → 一覧にサムネイル表示
- [ ] 詳細ページで画像変更/削除
- [ ] 10MB超や非画像ファイルでエラー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)