### PR TITLE
管理者メンバー画面でロール表示・変更を可能に

### DIFF
--- a/src/app/(admin)/admin/members/page.tsx
+++ b/src/app/(admin)/admin/members/page.tsx
@@ -14,11 +14,26 @@ import MessageBanner from '@/components/MessageBanner'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import EmptyState from '@/components/EmptyState'
 
+type AdminRole = 'admin' | 'superadmin' | 'hr'
+
 type AdminMember = {
   id: string
   name: string
   email: string
+  role: AdminRole
   createdAt: string
+}
+
+const ROLE_LABEL: Record<AdminRole, string> = {
+  superadmin: 'Super Admin',
+  hr: 'HR（人事）',
+  admin: '管理者',
+}
+
+const ROLE_BADGE_STYLE: Record<AdminRole, string> = {
+  superadmin: 'bg-amber-500/15 text-amber-300 border border-amber-500/30',
+  hr: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
+  admin: 'bg-[var(--md-sys-color-surface-container-high)] text-[var(--md-sys-color-on-surface-variant)] border border-transparent',
 }
 
 export default function AdminMembersPage() {
@@ -35,6 +50,9 @@ export default function AdminMembersPage() {
   // 削除確認モーダル
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null)
 
+  // ロール変更
+  const [roleUpdatingId, setRoleUpdatingId] = useState<string | null>(null)
+
   // パスワード再発行
   const [resetTarget, setResetTarget] = useState<{ id: string; name: string; email: string } | null>(null)
   const [resettingId, setResettingId] = useState<string | null>(null)
@@ -45,7 +63,8 @@ export default function AdminMembersPage() {
     if (status === 'unauthenticated') router.push('/admin/login')
     if (status === 'authenticated') {
       const sessionUser = session.user as any
-      if (sessionUser.role !== 'admin') router.push('/')
+      const allowed = ['admin', 'superadmin', 'hr']
+      if (!allowed.includes(sessionUser.role)) router.push('/')
     }
   }, [status, session, router])
 
@@ -130,8 +149,30 @@ export default function AdminMembersPage() {
     }
   }
 
+  async function handleChangeRole(id: string, newRole: AdminRole) {
+    setRoleUpdatingId(id)
+    setMessage(null)
+    const res = await fetch(`/api/admin/members/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role: newRole }),
+    })
+    setRoleUpdatingId(null)
+    if (res.ok) {
+      const updated = await res.json()
+      setMembers(prev => prev.map(m => (m.id === id ? { ...m, role: updated.role } : m)))
+      setMessage({ type: 'success', text: `${updated.name} さんのロールを ${ROLE_LABEL[updated.role as AdminRole]} に変更しました` })
+    } else {
+      const d = await res.json().catch(() => ({}))
+      setMessage({ type: 'error', text: d.error || 'ロール変更に失敗しました' })
+    }
+  }
+
   const sessionUser = session?.user as any
+  const sessionRole = sessionUser?.role as AdminRole | undefined
+  const canManageRoles = sessionRole === 'superadmin'
   const otherMembers = members.filter(m => m.id !== sessionUser?.id)
+  const myMember = members.find(m => m.id === sessionUser?.id)
 
   if (status === 'loading' || loading) {
     return <LoadingSpinner size="lg" fullPage label="読み込み中..." />
@@ -143,18 +184,20 @@ export default function AdminMembersPage() {
         title="メンバー管理"
         subtitle="管理ポータル"
         actions={
-          <Button
-            variant="filled"
-            size="sm"
-            onClick={() => { setShowForm(true); setMessage(null) }}
-            icon={
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-            }
-          >
-            メンバー追加
-          </Button>
+          canManageRoles ? (
+            <Button
+              variant="filled"
+              size="sm"
+              onClick={() => { setShowForm(true); setMessage(null) }}
+              icon={
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+              }
+            >
+              メンバー追加
+            </Button>
+          ) : null
         }
       />
 
@@ -188,6 +231,11 @@ export default function AdminMembersPage() {
               <p className="text-sm font-semibold text-[var(--md-sys-color-on-surface)]">{sessionUser?.name}</p>
               <p className="text-xs text-[var(--md-sys-color-on-surface-variant)]">{sessionUser?.email}</p>
             </div>
+            {myMember && (
+              <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${ROLE_BADGE_STYLE[myMember.role]}`}>
+                {ROLE_LABEL[myMember.role]}
+              </span>
+            )}
             <span className="text-xs font-medium bg-[var(--md-sys-color-surface-container-high)] text-[var(--md-sys-color-on-surface-variant)] px-2.5 py-1 rounded-full">
               ログイン中
             </span>
@@ -220,6 +268,22 @@ export default function AdminMembersPage() {
                 <p className="text-xs text-[var(--md-sys-color-on-surface-variant)] flex-shrink-0 hidden sm:block">
                   {format(new Date(member.createdAt), 'yyyy/M/d 追加', { locale: ja })}
                 </p>
+                {canManageRoles ? (
+                  <select
+                    value={member.role}
+                    disabled={roleUpdatingId === member.id}
+                    onChange={e => handleChangeRole(member.id, e.target.value as AdminRole)}
+                    className={`text-xs font-medium px-2 py-1 rounded-full ${ROLE_BADGE_STYLE[member.role]} cursor-pointer disabled:opacity-50`}
+                  >
+                    <option value="superadmin">Super Admin</option>
+                    <option value="hr">HR（人事）</option>
+                    <option value="admin">管理者</option>
+                  </select>
+                ) : (
+                  <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${ROLE_BADGE_STYLE[member.role]}`}>
+                    {ROLE_LABEL[member.role]}
+                  </span>
+                )}
                 <Button
                   variant="text"
                   size="sm"
@@ -229,16 +293,18 @@ export default function AdminMembersPage() {
                 >
                   PW再発行
                 </Button>
-                <Button
-                  variant="text"
-                  size="sm"
-                  danger
-                  disabled={deletingId === member.id || resettingId === member.id}
-                  loading={deletingId === member.id}
-                  onClick={() => setDeleteTarget({ id: member.id, name: member.name })}
-                >
-                  削除
-                </Button>
+                {canManageRoles && (
+                  <Button
+                    variant="text"
+                    size="sm"
+                    danger
+                    disabled={deletingId === member.id || resettingId === member.id}
+                    loading={deletingId === member.id}
+                    onClick={() => setDeleteTarget({ id: member.id, name: member.name })}
+                  >
+                    削除
+                  </Button>
+                )}
               </div>
             ))
           ) : (

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -2,22 +2,35 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+import { ADMIN_ROLES } from '@/lib/admin-auth'
 
-// 管理者メンバー削除
+async function requireAnyAdmin() {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as any
+  if (!session || !ADMIN_ROLES.includes(user?.role)) return null
+  return user as { id: string; role: 'admin' | 'superadmin' | 'hr' }
+}
+
+const patchSchema = z.object({
+  role: z.enum(['admin', 'superadmin', 'hr']),
+})
+
+// 管理者メンバー削除（superadmin のみ）
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getServerSession(authOptions)
-  const sessionUser = session?.user as any
-  if (!session || sessionUser.role !== 'admin') {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const user = await requireAnyAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (user.role !== 'superadmin') {
+    return NextResponse.json({ error: '管理者の削除は superadmin のみ実行できます' }, { status: 403 })
   }
 
   const { id } = await params
 
   // 自分自身は削除不可
-  if (id === sessionUser.id) {
+  if (id === user.id) {
     return NextResponse.json({ error: '自分自身は削除できません' }, { status: 400 })
   }
 
@@ -32,6 +45,59 @@ export async function DELETE(
     return NextResponse.json({ error: 'メンバーが見つかりません' }, { status: 404 })
   }
 
+  // 最後の superadmin は削除不可（ロックアウト防止）
+  if (admin.role === 'superadmin') {
+    const superadminCount = await prisma.admin.count({ where: { role: 'superadmin' } })
+    if (superadminCount <= 1) {
+      return NextResponse.json({ error: '最後の superadmin は削除できません' }, { status: 400 })
+    }
+  }
+
   await prisma.admin.delete({ where: { id } })
   return NextResponse.json({ ok: true })
+}
+
+// 管理者メンバーのロール変更（superadmin のみ）
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await requireAnyAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (user.role !== 'superadmin') {
+    return NextResponse.json({ error: 'ロール変更は superadmin のみ実行できます' }, { status: 403 })
+  }
+
+  const { id } = await params
+  const body = await request.json()
+  const parsed = patchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+  const newRole = parsed.data.role
+
+  // 自分自身のロール変更は不可（誤操作防止 + ロックアウト防止）
+  if (id === user.id) {
+    return NextResponse.json({ error: '自分自身のロールは変更できません' }, { status: 400 })
+  }
+
+  const target = await prisma.admin.findUnique({ where: { id } })
+  if (!target) {
+    return NextResponse.json({ error: 'メンバーが見つかりません' }, { status: 404 })
+  }
+
+  // 最後の superadmin の降格は不可
+  if (target.role === 'superadmin' && newRole !== 'superadmin') {
+    const superadminCount = await prisma.admin.count({ where: { role: 'superadmin' } })
+    if (superadminCount <= 1) {
+      return NextResponse.json({ error: '最後の superadmin は降格できません' }, { status: 400 })
+    }
+  }
+
+  const updated = await prisma.admin.update({
+    where: { id },
+    data: { role: newRole },
+    select: { id: true, name: true, email: true, role: true, createdAt: true },
+  })
+  return NextResponse.json(updated)
 }

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -6,34 +6,40 @@ import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 import { sendWelcomeWithPasswordEmail } from '@/lib/mailer'
 import { generateSecurePassword } from '@/lib/password-utils'
+import { ADMIN_ROLES } from '@/lib/admin-auth'
 
 const createMemberSchema = z.object({
   name:  z.string().min(1, '氏名は必須です').max(100),
   email: z.string().email('有効なメールアドレスを入力してください'),
+  role:  z.enum(['admin', 'superadmin', 'hr']).optional(),
 })
 
-// 管理者メンバー一覧取得
-export async function GET() {
+async function requireAnyAdmin() {
   const session = await getServerSession(authOptions)
-  const sessionUser = session?.user as any
-  if (!session || sessionUser.role !== 'admin') {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const user = session?.user as any
+  if (!session || !ADMIN_ROLES.includes(user?.role)) return null
+  return user as { id: string; role: 'admin' | 'superadmin' | 'hr' }
+}
+
+// 管理者メンバー一覧取得（admin/superadmin/hr 共通で閲覧可）
+export async function GET() {
+  const user = await requireAnyAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const members = await prisma.admin.findMany({
-    select: { id: true, name: true, email: true, createdAt: true },
+    select: { id: true, name: true, email: true, role: true, createdAt: true },
     orderBy: { createdAt: 'asc' },
   })
 
   return NextResponse.json(members)
 }
 
-// 管理者メンバー追加
+// 管理者メンバー追加（superadmin のみ）
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions)
-  const sessionUser = session?.user as any
-  if (!session || sessionUser.role !== 'admin') {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const user = await requireAnyAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (user.role !== 'superadmin') {
+    return NextResponse.json({ error: '管理者の追加は superadmin のみ実行できます' }, { status: 403 })
   }
 
   const body = await request.json()
@@ -43,7 +49,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error }, { status: 400 })
   }
 
-  const { name, email } = parsed.data
+  const { name, email, role } = parsed.data
 
   const existing = await prisma.admin.findUnique({ where: { email } })
   if (existing) {
@@ -53,8 +59,8 @@ export async function POST(request: NextRequest) {
   const rawPassword = generateSecurePassword()
   const hashed = await bcrypt.hash(rawPassword, 10)
   const member = await prisma.admin.create({
-    data: { name, email, password: hashed },
-    select: { id: true, name: true, email: true, createdAt: true },
+    data: { name, email, password: hashed, role: role ?? 'admin' },
+    select: { id: true, name: true, email: true, role: true, createdAt: true },
   })
 
   // 招待メール送信（ログイン情報を通知）


### PR DESCRIPTION
## 概要

管理ポータルのメンバー管理画面で、各管理者のロール (admin / superadmin / hr) を表示し、superadmin が他の管理者のロールを変更できるようにする。

## 変更内容

### API
- **GET `/api/admin/members`** — レスポンスに `role` を追加。閲覧は admin/superadmin/hr 全員可
- **POST `/api/admin/members`** — superadmin のみに制限（メンバー追加 + role 指定可、デフォルトは admin）
- **DELETE `/api/admin/members/[id]`** — superadmin のみに制限。最後の superadmin の削除を防止
- **PATCH `/api/admin/members/[id]`** — 新規。superadmin のみ。ロール変更
  - 自分自身のロール変更は不可
  - 最後の superadmin の降格は不可

### UI ([src/app/(admin)/admin/members/page.tsx](src/app/(admin)/admin/members/page.tsx))
- 既存のページ権限チェック `role !== 'admin'` を admin/superadmin/hr 許可に修正（superadmin/hr が締め出されるバグ修正）
- 自分のアカウント・他のメンバー両方にロールバッジ表示（superadmin=オレンジ、hr=緑、admin=グレー）
- superadmin がログイン中の場合、各メンバー行のバッジがプルダウンに変わりロール変更可能
- 「メンバー追加」「削除」ボタンは superadmin のみ表示

## Test plan
- [ ] superadmin でログイン → 全メンバーのロール変更ができ、メンバー追加/削除も可
- [ ] hr でログイン → ページに入れ、ロールバッジが見えるが変更不可。追加/削除ボタンが非表示
- [ ] admin でログイン → 同上
- [ ] 自分自身のロールはプルダウンに出ない（自分のアカウント枠は表示のみ）
- [ ] 最後の superadmin を別ロールに変更しようとすると 400 エラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)