### PR TITLE
fix: 管理者ログイン時にDBの role を JWT に反映

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -190,12 +190,13 @@ export const authOptions: NextAuthOptions = {
         }
 
         await resetLoginFailures(key)
+        const adminRole = (admin.role === 'superadmin' || admin.role === 'hr') ? admin.role : 'admin'
         return {
           id: admin.id,
           email: admin.email,
           name: admin.name,
           avatar: admin.avatar || null,
-          role: 'admin' as const,
+          role: adminRole,
         }
       },
     }),


### PR DESCRIPTION
## 概要
[src/lib/auth.ts](src/lib/auth.ts) の admin プロバイダの authorize() で `role: 'admin' as const` とハードコードされていたため、DB で `Admin.role` を `superadmin` / `hr` に変更しても、再ログイン後の JWT には常に `admin` が乗っていた。

DB の `admin.role` を読み取り、`'superadmin' | 'hr' | 'admin'` のいずれかを JWT に反映するよう修正。

## 影響
- 既存ユーザー: JWT 再発行時(再ログイン時)から正しいロールが反映される
- DB 値が想定外の文字列だった場合は安全側で `'admin'` にフォールバック

## Test plan
- [ ] superadmin ロールの管理者でログイン → メンバー管理画面に「メンバー追加」ボタンが表示される
- [ ] superadmin ロールの管理者でログイン → 社員情報画面に「+ 社員を追加」ボタンが表示される
- [ ] hr ロールの管理者でログイン → 社員情報の機微フィールドが閲覧/編集できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)