### PR TITLE
社員情報にCSVインポート機能を追加

### DIFF
--- a/src/app/(admin)/admin/employees/page.tsx
+++ b/src/app/(admin)/admin/employees/page.tsx
@@ -31,6 +31,39 @@ export default function EmployeeListPage() {
   const [search, setSearch] = useState('')
   const [showResigned, setShowResigned] = useState(false)
 
+  // CSVインポート
+  const [importOpen, setImportOpen] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [importResult, setImportResult] = useState<{ created: number; errors: { row: number; message: string }[] } | null>(null)
+  const [importError, setImportError] = useState('')
+
+  function refresh() {
+    fetch('/api/admin/employees')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setEmployees)
+  }
+
+  async function handleImport(file: File) {
+    setImporting(true)
+    setImportError('')
+    setImportResult(null)
+    try {
+      const fd = new FormData()
+      fd.append('file', file)
+      const res = await fetch('/api/admin/employees/import', { method: 'POST', body: fd })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok && !data.created) {
+        setImportError(data.error ?? 'インポートに失敗しました')
+        if (Array.isArray(data.errors)) setImportResult({ created: 0, errors: data.errors })
+        return
+      }
+      setImportResult({ created: data.created ?? 0, errors: data.errors ?? [] })
+      if (data.created > 0) refresh()
+    } finally {
+      setImporting(false)
+    }
+  }
+
   useEffect(() => {
     if (status === 'unauthenticated') router.push('/admin/login')
   }, [status, router])
@@ -73,14 +106,113 @@ export default function EmployeeListPage() {
           </p>
         </div>
         {canEdit && (
-          <button
-            onClick={() => router.push('/admin/employees/new')}
-            style={{ padding: '10px 16px', borderRadius: 8, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
-          >
-            + 社員を追加
-          </button>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              onClick={() => { setImportResult(null); setImportError(''); setImportOpen(true) }}
+              style={{ padding: '10px 16px', borderRadius: 8, border: '1px solid var(--md-sys-color-outline)', cursor: 'pointer', background: 'transparent', color: 'var(--md-sys-color-on-surface)', fontSize: 14, fontWeight: 600 }}
+            >
+              CSVインポート
+            </button>
+            <button
+              onClick={() => router.push('/admin/employees/new')}
+              style={{ padding: '10px 16px', borderRadius: 8, background: 'var(--md-sys-color-primary)', color: 'var(--md-sys-color-on-primary)', border: 'none', fontSize: 14, fontWeight: 600, cursor: 'pointer' }}
+            >
+              + 社員を追加
+            </button>
+          </div>
         )}
       </div>
+
+      {importOpen && (
+        <div
+          onClick={() => !importing && setImportOpen(false)}
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: 16 }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{ background: 'var(--md-sys-color-surface)', borderRadius: 16, padding: 24, width: '100%', maxWidth: 600, maxHeight: '85vh', overflowY: 'auto' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700 }}>社員情報をCSVインポート</h2>
+              <button onClick={() => !importing && setImportOpen(false)} style={{ background: 'transparent', border: 'none', color: 'var(--md-sys-color-on-surface-variant)', fontSize: 22, cursor: 'pointer', lineHeight: 1 }}>×</button>
+            </div>
+
+            <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--md-sys-color-on-surface-variant)' }}>
+              CSVファイルから社員情報を一括登録できます。サンプルCSVをダウンロードして列構成をご確認ください。
+            </p>
+
+            <div style={{ marginBottom: 16 }}>
+              <a
+                href="/api/admin/employees/import"
+                download="employees-import-template.csv"
+                style={{ display: 'inline-block', padding: '8px 14px', borderRadius: 8, border: '1px solid var(--md-sys-color-outline)', textDecoration: 'none', color: 'var(--md-sys-color-on-surface)', fontSize: 13 }}
+              >
+                ⬇ サンプルCSVをダウンロード
+              </a>
+            </div>
+
+            <div style={{ marginBottom: 16, padding: 12, background: 'var(--md-sys-color-surface-container-high)', borderRadius: 8, fontSize: 12, color: 'var(--md-sys-color-on-surface-variant)', lineHeight: 1.6 }}>
+              <strong style={{ color: 'var(--md-sys-color-on-surface)' }}>仕様:</strong><br />
+              ・必須列: 従業員番号 / 苗字 / 名前<br />
+              ・日付列（入社・退社・生年月日）: <code>YYYY-MM-DD</code> 形式<br />
+              ・<strong>機微情報</strong>（年金/保険/在留カード/振込先）は自動で暗号化保存<br />
+              ・婚姻状況: 「未婚」または「既婚」<br />
+              ・従業員番号が既に登録済み、または CSV 内で重複している行はスキップ
+            </div>
+
+            {!importResult && (
+              <label style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px 16px', borderRadius: 12, border: '2px dashed var(--md-sys-color-outline-variant)', cursor: importing ? 'wait' : 'pointer', fontSize: 13, opacity: importing ? 0.6 : 1 }}>
+                {importing ? 'インポート中…' : '📎 CSVファイルを選択'}
+                <input
+                  type="file"
+                  accept=".csv,text/csv"
+                  hidden
+                  onChange={e => { const f = e.target.files?.[0]; if (f) handleImport(f) }}
+                />
+              </label>
+            )}
+
+            {importError && (
+              <div style={{ marginTop: 12, padding: '10px 14px', borderRadius: 8, background: 'rgba(248,113,113,0.15)', color: '#f87171', fontSize: 13 }}>
+                {importError}
+              </div>
+            )}
+
+            {importResult && (
+              <div style={{ marginTop: 12 }}>
+                <div style={{ padding: '12px 14px', borderRadius: 8, background: importResult.created > 0 ? 'rgba(74,222,128,0.15)' : 'rgba(251,191,36,0.15)', color: importResult.created > 0 ? '#4ade80' : '#fbbf24', fontSize: 13, marginBottom: 12 }}>
+                  ✓ {importResult.created} 件の社員を登録しました
+                  {importResult.errors.length > 0 && `（${importResult.errors.length} 件はエラーでスキップ）`}
+                </div>
+                {importResult.errors.length > 0 && (
+                  <div style={{ maxHeight: 240, overflowY: 'auto', border: '1px solid var(--md-sys-color-outline-variant)', borderRadius: 8, padding: 12 }}>
+                    <div style={{ fontSize: 12, fontWeight: 600, marginBottom: 8 }}>エラー詳細:</div>
+                    {importResult.errors.map((e, i) => (
+                      <div key={i} style={{ fontSize: 12, color: '#f87171', marginBottom: 4 }}>
+                        行 {e.row}: {e.message}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+                  <button
+                    onClick={() => { setImportResult(null); setImportError('') }}
+                    style={{ padding: '8px 14px', borderRadius: 8, border: '1px solid var(--md-sys-color-outline)', cursor: 'pointer', background: 'transparent', color: 'var(--md-sys-color-on-surface)', fontSize: 13 }}
+                  >
+                    続けてインポート
+                  </button>
+                  <button
+                    onClick={() => setImportOpen(false)}
+                    style={{ padding: '8px 22px', borderRadius: 8, border: 'none', cursor: 'pointer', background: '#4f8ef7', color: '#fff', fontSize: 13, fontWeight: 700 }}
+                  >
+                    閉じる
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
         <input

--- a/src/app/api/admin/employees/import/route.ts
+++ b/src/app/api/admin/employees/import/route.ts
@@ -1,0 +1,255 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { parseCsv, buildCsv } from '@/lib/csv-parser'
+import { requireRole } from '@/lib/admin-auth'
+import { encField, HIRE_TYPES, EMPLOYMENT_TYPES, RESIGN_TYPES, GENDERS, MARITAL_STATUSES } from '@/lib/employee-utils'
+
+/**
+ * CSV ヘッダー（日本語）→ Employee の入力フィールド名 のマッピング。
+ * `encrypt: true` の項目は AES-256-GCM で暗号化して *Enc 列に保存する。
+ */
+type Column = {
+  header: string
+  field: string
+  required?: boolean
+  encrypt?: boolean
+  enumValues?: readonly string[]
+  date?: boolean
+}
+
+const COLUMN_MAP: Column[] = [
+  { header: '従業員番号',           field: 'employeeNumber', required: true },
+  { header: '苗字',                 field: 'lastName',       required: true },
+  { header: '名前',                 field: 'firstName',      required: true },
+  { header: '苗字フリガナ',         field: 'lastNameKana' },
+  { header: '名前フリガナ',         field: 'firstNameKana' },
+  { header: '入社年月日',           field: 'hireDate', date: true },
+  { header: '入社区分',             field: 'hireType', enumValues: HIRE_TYPES },
+  { header: '雇用形態',             field: 'employmentType', enumValues: EMPLOYMENT_TYPES },
+  { header: '所属部署',             field: 'department' },
+  { header: '肩書き',               field: 'jobTitle' },
+  { header: '職種',                 field: 'jobCategory' },
+  { header: '職務内容',             field: 'jobDescription' },
+  { header: '退社年月日',           field: 'resignDate', date: true },
+  { header: '退職区分',             field: 'resignType', enumValues: RESIGN_TYPES },
+  { header: '性別',                 field: 'gender', enumValues: GENDERS },
+  { header: '社用メール',           field: 'workEmail' },
+  { header: '社用電話',             field: 'workPhone' },
+  { header: '生年月日',             field: 'dateOfBirth', date: true },
+  { header: '住所',                 field: 'address' },
+  { header: '緊急連絡先',           field: 'emergencyContact' },
+  { header: '個人電話',             field: 'personalPhone' },
+  { header: '基礎年金番号',         field: 'basicPensionNumber', encrypt: true },
+  { header: '健康保険番号',         field: 'healthInsuranceNumber', encrypt: true },
+  { header: '雇用保険番号',         field: 'employmentInsuranceNumber', encrypt: true },
+  { header: '在留カード番号',       field: 'residenceCardNumber', encrypt: true },
+  { header: '給与振込先',           field: 'payrollBankInfo', encrypt: true },
+  { header: '保有資格',             field: 'qualifications' },
+  { header: '履歴書URL',            field: 'resumeDriveUrl' },
+  { header: '名刺URL',              field: 'businessCardDriveUrl' },
+  { header: 'プロフィール写真URL',  field: 'profilePhotoDriveUrl' },
+  { header: '婚姻状況',             field: 'maritalStatus', enumValues: MARITAL_STATUSES },
+]
+
+const MARITAL_FROM_LABEL: Record<string, string> = {
+  '未婚': 'single', 'single': 'single',
+  '既婚': 'married', 'married': 'married',
+}
+
+function parseDateLike(v: string): Date | null {
+  const t = v.trim()
+  if (!t) return null
+  // YYYY-MM-DD / YYYY/MM/DD / YYYYMMDD
+  const m1 = t.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/)
+  if (m1) {
+    const d = new Date(Date.UTC(Number(m1[1]), Number(m1[2]) - 1, Number(m1[3])))
+    return isNaN(d.getTime()) ? null : d
+  }
+  const m2 = t.match(/^(\d{4})(\d{2})(\d{2})$/)
+  if (m2) {
+    const d = new Date(Date.UTC(Number(m2[1]), Number(m2[2]) - 1, Number(m2[3])))
+    return isNaN(d.getTime()) ? null : d
+  }
+  return null
+}
+
+/** GET: サンプルCSV ダウンロード */
+export async function GET() {
+  const user = await requireRole(['superadmin', 'hr'])
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const headers = COLUMN_MAP.map(c => (c.required ? `${c.header}*` : c.header))
+  const sample = [
+    '028', '山田', '太郎', 'ヤマダ', 'タロウ',
+    '2024-04-01', '中途', '正社員', '営業部', 'マネージャー', '営業', '法人営業',
+    '', '', '男性', 't.yamada@example.com', '090-1234-5678',
+    '1990-05-20', '東京都渋谷区...', '配偶者 山田花子 090-0000-0000', '090-9999-8888',
+    '1234-567890', '12345678', 'AB1234567890', 'AB12345678', 'みずほ銀行 渋谷支店 普通 1234567 ヤマダ タロウ',
+    '日商簿記2級, TOEIC 800', 'https://drive.google.com/...', 'https://drive.google.com/...', 'https://drive.google.com/...',
+    '既婚',
+  ]
+  const csv = buildCsv([headers, sample])
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="employees-import-template.csv"',
+    },
+  })
+}
+
+/** POST: CSV をパースして一括登録 */
+export async function POST(req: NextRequest) {
+  const user = await requireRole(['superadmin', 'hr'])
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  let csvText: string
+  const contentType = req.headers.get('content-type') ?? ''
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await req.formData()
+    const file = formData.get('file') as File | null
+    if (!file) return NextResponse.json({ error: 'ファイルが選択されていません' }, { status: 400 })
+    if (file.size > 5 * 1024 * 1024) return NextResponse.json({ error: 'ファイルサイズは5MB以下にしてください' }, { status: 400 })
+    csvText = await file.text()
+  } else {
+    const body = await req.json().catch(() => ({}))
+    csvText = typeof body.csv === 'string' ? body.csv : ''
+    if (!csvText) return NextResponse.json({ error: 'CSV データが空です' }, { status: 400 })
+  }
+
+  const rows = parseCsv(csvText)
+  if (rows.length < 2) {
+    return NextResponse.json({ error: 'ヘッダー行とデータ行が必要です' }, { status: 400 })
+  }
+
+  // ヘッダー行のマッピング（末尾の * は除去して比較）
+  const headerRow = rows[0].map(h => h.trim().replace(/\*+$/, ''))
+  const headerToIndex: Record<string, number> = {}
+  for (let i = 0; i < headerRow.length; i++) {
+    headerToIndex[headerRow[i]] = i
+  }
+
+  // 必須ヘッダーチェック
+  const missingRequired = COLUMN_MAP
+    .filter(c => c.required && !(c.header in headerToIndex))
+    .map(c => c.header)
+  if (missingRequired.length > 0) {
+    return NextResponse.json({
+      error: `必須列が見つかりません: ${missingRequired.join(', ')}`,
+    }, { status: 400 })
+  }
+
+  const errors: { row: number; message: string }[] = []
+  const records: Record<string, unknown>[] = []
+  const seenNumbers = new Set<string>()
+
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r]
+    // 空行スキップ
+    if (row.every(c => !c?.trim())) continue
+
+    const get = (header: string) => {
+      const idx = headerToIndex[header]
+      return idx === undefined ? '' : (row[idx] ?? '').trim()
+    }
+
+    const rec: Record<string, unknown> = {}
+    let invalid = false
+
+    for (const col of COLUMN_MAP) {
+      const raw = get(col.header)
+
+      if (col.required && !raw) {
+        errors.push({ row: r + 1, message: `${col.header} が空です` })
+        invalid = true
+        continue
+      }
+      if (!raw) {
+        // 任意項目で空
+        if (col.encrypt) {
+          rec[`${col.field}Enc`] = null
+        } else {
+          rec[col.field] = null
+        }
+        continue
+      }
+
+      if (col.date) {
+        const d = parseDateLike(raw)
+        if (!d) {
+          errors.push({ row: r + 1, message: `${col.header} の日付形式が不正: "${raw}"（YYYY-MM-DD）` })
+          invalid = true
+          continue
+        }
+        rec[col.field] = d
+        continue
+      }
+
+      if (col.field === 'maritalStatus') {
+        const m = MARITAL_FROM_LABEL[raw]
+        if (!m) {
+          errors.push({ row: r + 1, message: `婚姻状況が不正: "${raw}"（"未婚" or "既婚"）` })
+          invalid = true
+          continue
+        }
+        rec.maritalStatus = m
+        continue
+      }
+
+      if (col.enumValues && !(col.enumValues as readonly string[]).includes(raw)) {
+        errors.push({
+          row: r + 1,
+          message: `${col.header} が候補に含まれません: "${raw}"（候補: ${col.enumValues.join(' / ')}）`,
+        })
+        invalid = true
+        continue
+      }
+
+      if (col.encrypt) {
+        rec[`${col.field}Enc`] = encField(raw)
+      } else {
+        rec[col.field] = raw
+      }
+    }
+
+    if (!invalid) {
+      const num = String(rec.employeeNumber)
+      if (seenNumbers.has(num)) {
+        errors.push({ row: r + 1, message: `従業員番号が CSV 内で重複: "${num}"` })
+      } else {
+        seenNumbers.add(num)
+        records.push(rec)
+      }
+    }
+  }
+
+  if (records.length === 0) {
+    return NextResponse.json({ error: '登録できる行がありません', errors }, { status: 400 })
+  }
+
+  // 既存の employeeNumber と衝突する行をエラーにする
+  const numbers = records.map(r => r.employeeNumber as string)
+  const existing = await prisma.employee.findMany({
+    where: { employeeNumber: { in: numbers } },
+    select: { employeeNumber: true },
+  })
+  const existingSet = new Set(existing.map(e => e.employeeNumber))
+
+  const created: { row: number; employeeNumber: string }[] = []
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i]
+    const num = rec.employeeNumber as string
+    if (existingSet.has(num)) {
+      errors.push({ row: i + 2, message: `従業員番号 "${num}" は既に登録されています` })
+      continue
+    }
+    try {
+      const employee = await prisma.employee.create({ data: rec as any })
+      created.push({ row: i + 2, employeeNumber: employee.employeeNumber })
+    } catch (e: any) {
+      errors.push({ row: i + 2, message: e?.message ?? '登録に失敗しました' })
+    }
+  }
+
+  return NextResponse.json({ created: created.length, errors })
+}


### PR DESCRIPTION
## 概要
社員情報をCSVから一括登録できるようにする。サンプルCSVテンプレートのダウンロードも可能。

## API
- **GET `/api/admin/employees/import`** — サンプルCSVテンプレートをダウンロード
- **POST `/api/admin/employees/import`** — multipart/form-data でCSVをアップロード、一括登録
- 権限: **superadmin / hr のみ**（機微情報を含むため）

## CSV 仕様
- 必須列: 従業員番号 / 苗字 / 名前
- 全 31 列（社員ID 以外の全フィールド）
- 日付列（入社・退社・生年月日）: `YYYY-MM-DD` / `YYYY/MM/DD` / `YYYYMMDD`
- 列挙型（入社区分/雇用形態/退職区分/性別/婚姻状況）: 値検証
- **機微情報（基礎年金/健康保険/雇用保険/在留カード/給与振込先）は AES-256-GCM で自動暗号化保存**
- 従業員番号の重複（CSV 内 / 既存DB）はスキップしエラー報告

## UI
- 一覧ページ右上に「CSVインポート」ボタン追加
- モーダル: サンプルDL → ファイル選択 → 結果表示（登録件数 + エラー一覧）

## Test plan
- [ ] superadmin/hr で「CSVインポート」ボタン表示
- [ ] admin では非表示（権限不足で 401）
- [ ] サンプルCSVがダウンロードできる
- [ ] サンプル通りにCSVを編集してアップロード → 全件登録される
- [ ] 機微情報がDB上で ciphertext で保存される（`xxx:xxx:xxx` 形式）
- [ ] 既存従業員番号と重複する行はエラーでスキップ
- [ ] 日付形式が不正な行はエラーでスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)