### PR TITLE
研修動画の店舗別視聴トラッキング機能を追加

### DIFF
--- a/prisma/migrations/20260511020000_add_training_video_view/migration.sql
+++ b/prisma/migrations/20260511020000_add_training_video_view/migration.sql
@@ -1,0 +1,21 @@
+-- 研修動画の店舗別視聴ステータス
+CREATE TABLE "TrainingVideoView" (
+  "id"              TEXT NOT NULL,
+  "trainingVideoId" TEXT NOT NULL,
+  "storeId"         TEXT NOT NULL,
+  "playCount"       INTEGER NOT NULL DEFAULT 0,
+  "firstViewedAt"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "lastViewedAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "TrainingVideoView_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TrainingVideoView_trainingVideoId_storeId_key" ON "TrainingVideoView"("trainingVideoId", "storeId");
+CREATE INDEX "TrainingVideoView_storeId_idx" ON "TrainingVideoView"("storeId");
+CREATE INDEX "TrainingVideoView_trainingVideoId_idx" ON "TrainingVideoView"("trainingVideoId");
+
+ALTER TABLE "TrainingVideoView" ADD CONSTRAINT "TrainingVideoView_trainingVideoId_fkey"
+  FOREIGN KEY ("trainingVideoId") REFERENCES "TrainingVideo"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "TrainingVideoView" ADD CONSTRAINT "TrainingVideoView_storeId_fkey"
+  FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -118,6 +118,7 @@ model Store {
   inquiries  Inquiry[]
   lineChannels LineChannel[]
   formsAsCustomerStore Form[]   @relation("FormCustomerStore")
+  trainingVideoViews   TrainingVideoView[]
   // 運営者（複数店舗を1運営者が運営できる）
   operatorId String?
   operator   Operator? @relation(fields: [operatorId], references: [id], onDelete: SetNull)
@@ -587,12 +588,29 @@ model TrainingVideo {
   keyPoints     String?        @db.Text   // 重要ポイント(JSON配列)
   adminId       String
   admin         Admin          @relation(fields: [adminId], references: [id])
+  views         TrainingVideoView[]
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 
   @@index([categoryId])
   @@index([isPublished])
   @@index([adminId])
+}
+
+// 研修動画の店舗別視聴ステータス（店舗×動画でユニーク、再生回数を保持）
+model TrainingVideoView {
+  id              String        @id @default(cuid())
+  trainingVideoId String
+  trainingVideo   TrainingVideo @relation(fields: [trainingVideoId], references: [id], onDelete: Cascade)
+  storeId         String
+  store           Store         @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  playCount       Int           @default(0)
+  firstViewedAt   DateTime      @default(now())
+  lastViewedAt    DateTime      @default(now())
+
+  @@unique([trainingVideoId, storeId])
+  @@index([storeId])
+  @@index([trainingVideoId])
 }
 
 // コミュニティスレッド

--- a/src/app/(admin)/admin/training-videos/page.tsx
+++ b/src/app/(admin)/admin/training-videos/page.tsx
@@ -37,6 +37,27 @@ type TrainingVideo = {
   keyPoints: string | null
   admin: { name: string }
   createdAt: string
+  viewedStoreCount?: number
+  totalActiveStores?: number
+  totalPlays?: number
+}
+
+type ViewStat = {
+  storeId: string
+  storeName: string
+  storeCode: string
+  viewed: boolean
+  playCount: number
+  firstViewedAt: string | null
+  lastViewedAt: string | null
+}
+
+type ViewsResponse = {
+  video: { id: string; title: string }
+  viewedCount: number
+  totalStores: number
+  totalPlays: number
+  stats: ViewStat[]
 }
 
 function formatFileSize(bytes: number | null): string {
@@ -79,6 +100,25 @@ export default function AdminTrainingVideosPage() {
   const [filterCatId, setFilterCatId] = useState<string>('all')
   // 詳細モーダル
   const [detailVideo, setDetailVideo] = useState<TrainingVideo | null>(null)
+
+  // 視聴状況モーダル
+  const [viewsModalVideo, setViewsModalVideo] = useState<TrainingVideo | null>(null)
+  const [viewsData, setViewsData] = useState<ViewsResponse | null>(null)
+  const [viewsLoading, setViewsLoading] = useState(false)
+  const [viewsFilter, setViewsFilter] = useState<'all' | 'viewed' | 'unviewed'>('all')
+
+  async function openViewsModal(v: TrainingVideo) {
+    setViewsModalVideo(v)
+    setViewsData(null)
+    setViewsFilter('all')
+    setViewsLoading(true)
+    try {
+      const res = await fetch(`/api/admin/training-videos/${v.id}/views`)
+      if (res.ok) setViewsData(await res.json())
+    } finally {
+      setViewsLoading(false)
+    }
+  }
 
   useEffect(() => {
     if (status === 'unauthenticated') router.push('/admin/login')
@@ -729,6 +769,23 @@ export default function AdminTrainingVideosPage() {
                       </div>
                     </div>
 
+                    {/* 視聴状況サマリ */}
+                    {typeof v.totalActiveStores === 'number' && v.totalActiveStores > 0 && (
+                      <button
+                        onClick={() => openViewsModal(v)}
+                        className="mt-3 w-full px-3 py-2 rounded-xl border border-[var(--md-sys-color-outline-variant)] hover:bg-[var(--md-sys-color-surface-container)] flex items-center justify-between transition-colors"
+                      >
+                        <span className="text-xs font-medium text-[var(--md-sys-color-on-surface-variant)]">店舗視聴状況</span>
+                        <span className="text-xs font-semibold text-[var(--md-sys-color-on-surface)]">
+                          <span className="text-emerald-600 dark:text-emerald-400">{v.viewedStoreCount ?? 0}</span>
+                          <span className="text-[var(--md-sys-color-on-surface-variant)]"> / {v.totalActiveStores} 店舗</span>
+                          {typeof v.totalPlays === 'number' && v.totalPlays > 0 && (
+                            <span className="text-[var(--md-sys-color-on-surface-variant)]"> ・ {v.totalPlays}回再生</span>
+                          )}
+                        </span>
+                      </button>
+                    )}
+
                     {/* 詳細を見る */}
                     <button
                       onClick={() => setDetailVideo(v)}
@@ -861,6 +918,109 @@ export default function AdminTrainingVideosPage() {
                 <div className="flex gap-2 ml-auto">
                   <Button size="sm" variant="tonal" onClick={() => { startEditVideo(detailVideo); setDetailVideo(null) }}>編集</Button>
                 </div>
+              </div>
+            </div>
+          )
+        })()}
+      </Modal>
+
+      {/* ===== 視聴状況モーダル ===== */}
+      <Modal
+        open={!!viewsModalVideo}
+        onClose={() => { setViewsModalVideo(null); setViewsData(null) }}
+        title={viewsModalVideo ? `店舗視聴状況: ${viewsModalVideo.title}` : '視聴状況'}
+        size="lg"
+      >
+        {viewsLoading && (
+          <div className="py-10 text-center text-sm text-[var(--md-sys-color-on-surface-variant)]">読み込み中...</div>
+        )}
+        {!viewsLoading && viewsData && (() => {
+          const filtered = viewsData.stats.filter(s => {
+            if (viewsFilter === 'viewed') return s.viewed
+            if (viewsFilter === 'unviewed') return !s.viewed
+            return true
+          })
+          return (
+            <div className="space-y-4">
+              {/* サマリカード */}
+              <div className="grid grid-cols-3 gap-3">
+                <div className="rounded-xl px-4 py-3 bg-emerald-500/10 border border-emerald-500/20">
+                  <p className="text-[10px] uppercase tracking-wide text-emerald-600 dark:text-emerald-400 font-bold">視聴済み</p>
+                  <p className="text-xl font-bold text-emerald-600 dark:text-emerald-400 mt-1">
+                    {viewsData.viewedCount}
+                    <span className="text-xs text-[var(--md-sys-color-on-surface-variant)] font-normal ml-1">/ {viewsData.totalStores}</span>
+                  </p>
+                </div>
+                <div className="rounded-xl px-4 py-3 bg-amber-500/10 border border-amber-500/20">
+                  <p className="text-[10px] uppercase tracking-wide text-amber-600 dark:text-amber-400 font-bold">未視聴</p>
+                  <p className="text-xl font-bold text-amber-600 dark:text-amber-400 mt-1">
+                    {viewsData.totalStores - viewsData.viewedCount}
+                  </p>
+                </div>
+                <div className="rounded-xl px-4 py-3 bg-[var(--md-sys-color-surface-container)] border border-[var(--md-sys-color-outline-variant)]">
+                  <p className="text-[10px] uppercase tracking-wide text-[var(--md-sys-color-on-surface-variant)] font-bold">合計再生回数</p>
+                  <p className="text-xl font-bold text-[var(--md-sys-color-on-surface)] mt-1">{viewsData.totalPlays}</p>
+                </div>
+              </div>
+
+              {/* フィルター */}
+              <div className="flex gap-2">
+                {([
+                  { key: 'all', label: 'すべて' },
+                  { key: 'viewed', label: '視聴済み' },
+                  { key: 'unviewed', label: '未視聴' },
+                ] as const).map(t => (
+                  <button
+                    key={t.key}
+                    onClick={() => setViewsFilter(t.key)}
+                    className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                      viewsFilter === t.key
+                        ? 'bg-[var(--admin-primary)] text-[var(--admin-on-primary)]'
+                        : 'bg-[var(--md-sys-color-surface-container)] text-[var(--md-sys-color-on-surface-variant)] hover:bg-[var(--md-sys-color-surface-container-high)]'
+                    }`}
+                  >
+                    {t.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* 店舗別テーブル */}
+              <div className="rounded-xl border border-[var(--md-sys-color-outline-variant)] overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-[var(--md-sys-color-surface-container)] text-[var(--md-sys-color-on-surface-variant)]">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-semibold">店舗</th>
+                      <th className="px-3 py-2 text-left font-semibold w-24">状態</th>
+                      <th className="px-3 py-2 text-right font-semibold w-20">再生回数</th>
+                      <th className="px-3 py-2 text-left font-semibold w-36">最終視聴</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.length === 0 ? (
+                      <tr>
+                        <td colSpan={4} className="px-3 py-8 text-center text-xs text-[var(--md-sys-color-on-surface-variant)]">該当する店舗がありません</td>
+                      </tr>
+                    ) : (
+                      filtered.map(s => (
+                        <tr key={s.storeId} className="border-t border-[var(--md-sys-color-outline-variant)]">
+                          <td className="px-3 py-2">
+                            <div className="font-medium">{s.storeName}</div>
+                            <div className="text-[10px] font-mono text-[var(--md-sys-color-on-surface-variant)]">{s.storeCode}</div>
+                          </td>
+                          <td className="px-3 py-2">
+                            <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${s.viewed ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400' : 'bg-amber-500/15 text-amber-600 dark:text-amber-400'}`}>
+                              {s.viewed ? '視聴済み' : '未視聴'}
+                            </span>
+                          </td>
+                          <td className="px-3 py-2 text-right font-mono">{s.playCount || '—'}</td>
+                          <td className="px-3 py-2 text-xs text-[var(--md-sys-color-on-surface-variant)]">
+                            {s.lastViewedAt ? format(new Date(s.lastViewedAt), 'yyyy/M/d HH:mm', { locale: ja }) : '—'}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
             </div>
           )

--- a/src/app/(store)/store/training-videos/[id]/page.tsx
+++ b/src/app/(store)/store/training-videos/[id]/page.tsx
@@ -28,6 +28,17 @@ export default function StoreTrainingVideoDetailPage() {
   const [video, setVideo] = useState<VideoDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
+  const [viewRecorded, setViewRecorded] = useState(false)
+
+  function handlePlay() {
+    // 1回の表示につき1回だけ記録（巻き戻し再生で多重カウントを避ける）
+    if (viewRecorded || !params.id) return
+    setViewRecorded(true)
+    fetch(`/api/store/training-videos/${params.id}/view`, { method: 'POST' }).catch(() => {
+      // 記録失敗しても再生体験は妨げない。次回のチャンスのため flag を戻す
+      setViewRecorded(false)
+    })
+  }
 
   useEffect(() => {
     if (status === 'unauthenticated') router.push('/store/login')
@@ -93,6 +104,7 @@ export default function StoreTrainingVideoDetailPage() {
           preload="metadata"
           poster={video.thumbnailUrl || undefined}
           controlsList="nodownload"
+          onPlay={handlePlay}
         />
       </div>
 

--- a/src/app/(store)/store/training-videos/page.tsx
+++ b/src/app/(store)/store/training-videos/page.tsx
@@ -15,6 +15,9 @@ type Video = {
   thumbnailUrl: string | null
   fileSize: number | null
   publishedAt: string
+  viewed: boolean
+  playCount: number
+  lastViewedAt: string | null
 }
 
 type CategoryWithVideos = {
@@ -127,6 +130,16 @@ export default function StoreTrainingVideosPage() {
                             <svg className="w-7 h-7 text-[var(--store-primary)] ml-1" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
                           </div>
                         </div>
+                        {/* 視聴ステータスバッジ */}
+                        <span
+                          className={`absolute top-2 right-2 text-[10px] font-bold px-2 py-1 rounded-full shadow-md ${
+                            video.viewed
+                              ? 'bg-emerald-500 text-white'
+                              : 'bg-amber-500 text-white'
+                          }`}
+                        >
+                          {video.viewed ? '✓ 閲覧済み' : '未閲覧'}
+                        </span>
                       </div>
                       <div className="p-4">
                         <h3 className="text-sm font-semibold text-[var(--md-sys-color-on-surface)] line-clamp-2 group-hover:text-[var(--store-primary)] transition-colors">

--- a/src/app/api/admin/training-videos/[id]/views/route.ts
+++ b/src/app/api/admin/training-videos/[id]/views/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/admin-auth'
+
+/** 指定動画の店舗別視聴状況。全店舗（未視聴含む）を返す。 */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await requireAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { id } = await params
+
+  const video = await prisma.trainingVideo.findUnique({
+    where: { id },
+    select: { id: true, title: true },
+  })
+  if (!video) return NextResponse.json({ error: '動画が見つかりません' }, { status: 404 })
+
+  const [stores, views] = await Promise.all([
+    prisma.store.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true, code: true },
+      orderBy: { name: 'asc' },
+    }),
+    prisma.trainingVideoView.findMany({
+      where: { trainingVideoId: id },
+      select: { storeId: true, playCount: true, firstViewedAt: true, lastViewedAt: true },
+    }),
+  ])
+
+  const viewMap = new Map(views.map(v => [v.storeId, v]))
+
+  const stats = stores.map(s => {
+    const v = viewMap.get(s.id)
+    return {
+      storeId: s.id,
+      storeName: s.name,
+      storeCode: s.code,
+      viewed: !!v,
+      playCount: v?.playCount ?? 0,
+      firstViewedAt: v?.firstViewedAt ?? null,
+      lastViewedAt: v?.lastViewedAt ?? null,
+    }
+  })
+
+  const viewedCount = stats.filter(s => s.viewed).length
+  const totalPlays = stats.reduce((sum, s) => sum + s.playCount, 0)
+
+  return NextResponse.json({
+    video,
+    viewedCount,
+    totalStores: stores.length,
+    totalPlays,
+    stats,
+  })
+}

--- a/src/app/api/admin/training-videos/route.ts
+++ b/src/app/api/admin/training-videos/route.ts
@@ -19,10 +19,29 @@ export async function GET() {
     include: {
       category: { select: { id: true, name: true } },
       admin: { select: { name: true } },
+      _count: { select: { views: true } },
     },
   })
 
-  return NextResponse.json(videos)
+  // 全店舗数を取得（視聴率の分母として）
+  const totalActiveStores = await prisma.store.count({ where: { isActive: true } })
+
+  // 各動画の合計再生回数を集計
+  const playSums = await prisma.trainingVideoView.groupBy({
+    by: ['trainingVideoId'],
+    _sum: { playCount: true },
+    where: { trainingVideoId: { in: videos.map(v => v.id) } },
+  })
+  const totalPlayMap = new Map(playSums.map(p => [p.trainingVideoId, p._sum.playCount ?? 0]))
+
+  const result = videos.map(v => ({
+    ...v,
+    viewedStoreCount: v._count.views,
+    totalActiveStores,
+    totalPlays: totalPlayMap.get(v.id) ?? 0,
+  }))
+
+  return NextResponse.json(result)
 }
 
 /** 動画作成 */

--- a/src/app/api/store/training-videos/[id]/view/route.ts
+++ b/src/app/api/store/training-videos/[id]/view/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+/** 視聴記録 — 店舗が動画を再生した時に呼ぶ。playCount を +1、lastViewedAt を now にする */
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as any
+  if (!session || user?.role !== 'store') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  // 公開済みかどうかを確認
+  const video = await prisma.trainingVideo.findFirst({
+    where: { id, isPublished: true },
+    select: { id: true },
+  })
+  if (!video) {
+    return NextResponse.json({ error: '動画が見つかりません' }, { status: 404 })
+  }
+
+  const now = new Date()
+  const view = await prisma.trainingVideoView.upsert({
+    where: {
+      trainingVideoId_storeId: { trainingVideoId: id, storeId: user.id },
+    },
+    create: {
+      trainingVideoId: id,
+      storeId: user.id,
+      playCount: 1,
+      firstViewedAt: now,
+      lastViewedAt: now,
+    },
+    update: {
+      playCount: { increment: 1 },
+      lastViewedAt: now,
+    },
+    select: { playCount: true, firstViewedAt: true, lastViewedAt: true },
+  })
+
+  return NextResponse.json(view)
+}

--- a/src/app/api/store/training-videos/route.ts
+++ b/src/app/api/store/training-videos/route.ts
@@ -11,6 +11,8 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const storeId = user.id as string
+
   // カテゴリごとにグループ化して返す
   const categories = await prisma.videoCategory.findMany({
     orderBy: { sortOrder: 'asc' },
@@ -29,18 +31,31 @@ export async function GET() {
           thumbnailUrl: true,
           fileSize: true,
           publishedAt: true,
+          views: {
+            where: { storeId },
+            select: { playCount: true, lastViewedAt: true },
+          },
         },
       },
     },
   })
 
-  // 動画があるカテゴリのみ返す
+  // 動画があるカテゴリのみ返し、各動画に viewed フラグを付与
   const result = categories
     .filter(c => c.videos.length > 0)
     .map(c => ({
       id: c.id,
       name: c.name,
-      videos: c.videos,
+      videos: c.videos.map(v => {
+        const view = v.views[0]
+        const { views, ...rest } = v
+        return {
+          ...rest,
+          viewed: !!view,
+          playCount: view?.playCount ?? 0,
+          lastViewedAt: view?.lastViewedAt ?? null,
+        }
+      }),
     }))
 
   return NextResponse.json(result)


### PR DESCRIPTION
## 概要
研修動画の再生を店舗ごとに記録し、管理ポータルで「どの店舗が何回再生したか」を確認できるようにする。店舗側は動画カードに視聴済み/未閲覧バッジを表示する。

## 変更内容

### Prisma
- 新規モデル `TrainingVideoView` (店舗×動画でユニーク、再生回数・初回/最終視聴日時を保持)
- マイグレーション SQL 同梱（`prisma/migrations/20260511020000_add_training_video_view/migration.sql`）

### API
- **POST `/api/store/training-videos/[id]/view`** (新規) — 店舗が再生した時に呼び出し、`playCount` を `+1` する upsert
- **GET `/api/store/training-videos`** — 各動画に `viewed` / `playCount` / `lastViewedAt` を含める
- **GET `/api/admin/training-videos`** — 各動画に `viewedStoreCount` / `totalActiveStores` / `totalPlays` を含める
- **GET `/api/admin/training-videos/[id]/views`** (新規) — 全店舗（未視聴含む）の視聴ステータス一覧

### UI

**店舗ページ** ([src/app/(store)/store/training-videos/page.tsx](src/app/(store)/store/training-videos/page.tsx)):
- 動画カードのサムネ右上に **「✓ 閲覧済み」/「未閲覧」** バッジ

**店舗動画詳細** ([src/app/(store)/store/training-videos/[id]/page.tsx](src/app/(store)/store/training-videos/[id]/page.tsx)):
- `<video onPlay>` で `POST /view` を呼び出し（1ページ訪問につき1回だけ送信）

**管理ポータル** ([src/app/(admin)/admin/training-videos/page.tsx](src/app/(admin)/admin/training-videos/page.tsx)):
- 動画カードに「店舗視聴 5/12 店舗 ・ 23回再生」サマリ + クリックで詳細モーダル
- 詳細モーダル: 視聴済み / 未視聴 / 合計再生回数のカード + 店舗別テーブル（フィルタ可）

## Test plan
- [ ] 店舗ログイン → 動画一覧で全て「未閲覧」バッジ
- [ ] 動画を再生 → DB に `TrainingVideoView` が作成、`playCount=1`
- [ ] 同一動画を再生 → `playCount=2`
- [ ] 一覧に戻ると当該動画が「✓ 閲覧済み」に変わる
- [ ] 管理者ログイン → 動画カードに「店舗視聴 1/N」表示
- [ ] 「店舗視聴状況」をクリック → モーダルで該当店舗が「視聴済み」、他は「未視聴」と表示
- [ ] フィルタ「視聴済み/未視聴」で絞り込みできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)