### PR TITLE
セールスパートナー: ユーザーメニュー折りたたみ + プロフィール編集 + 参加メンバー閲覧

### DIFF
--- a/src/app/(partner)/layout.tsx
+++ b/src/app/(partner)/layout.tsx
@@ -1,13 +1,32 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 import { useSession, signOut } from 'next-auth/react'
+
+const navItems = [
+  { href: '/partner/dashboard', label: 'ダッシュボード' },
+  { href: '/partner/customers', label: 'ライセンスキー顧客' },
+  { href: '/partner/members',   label: '参加メンバー' },
+]
 
 export default function PartnerLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
   const { data: session } = useSession()
   const user = session?.user as any
+  const [userMenuOpen, setUserMenuOpen] = useState(false)
+  const userMenuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
+        setUserMenuOpen(false)
+      }
+    }
+    if (userMenuOpen) document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [userMenuOpen])
 
   // ログイン・招待受諾画面はサイドバー無し
   const isPublic = pathname === '/partner/login' || pathname.startsWith('/partner/invite/')
@@ -15,20 +34,18 @@ export default function PartnerLayout({ children }: { children: React.ReactNode 
     return <div data-portal="partner">{children}</div>
   }
 
-  const navItems = [
-    { href: '/partner/dashboard', label: 'ダッシュボード' },
-    { href: '/partner/customers', label: 'ライセンスキー顧客' },
-  ]
-
   return (
     <div data-portal="partner" className="flex min-h-screen bg-[#0f1115] text-[#ededed]">
       <aside className="hidden lg:flex w-60 flex-col bg-[#0a0a0a] shadow-[inset_-1px_0_0_0_rgba(255,255,255,0.06)]">
+        {/* ヘッダー */}
         <div className="px-5 pt-5 pb-4">
           <p className="text-sm font-semibold">セールスパートナー</p>
           <p className="text-[10px] text-[#666]">買いクル</p>
         </div>
         <hr className="border-[rgba(255,255,255,0.06)] mx-4" />
-        <nav className="flex-1 px-3 py-2 space-y-0.5">
+
+        {/* ナビ */}
+        <nav className="flex-1 px-3 py-2 space-y-0.5 overflow-y-auto">
           {navItems.map(item => {
             const active = pathname === item.href || pathname.startsWith(item.href + '/')
             return (
@@ -46,17 +63,58 @@ export default function PartnerLayout({ children }: { children: React.ReactNode 
             )
           })}
         </nav>
-        <div className="px-4 py-3 border-t border-[rgba(255,255,255,0.06)]">
-          <p className="text-sm font-medium truncate">{user?.name ?? 'パートナー'}</p>
-          <p className="text-[11px] text-[#666] truncate">{user?.email ?? ''}</p>
+
+        {/* ユーザーメニュー（折りたたみ式） */}
+        <div className="relative shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)]" ref={userMenuRef}>
+          {/* ポップアップ */}
+          {userMenuOpen && (
+            <div className="absolute bottom-full left-2 right-2 mb-1 rounded-lg bg-[#141414] shadow-[0_0_0_1px_rgba(255,255,255,0.08),0_4px_12px_rgba(0,0,0,0.4)] overflow-hidden z-50">
+              <div className="py-1">
+                <Link
+                  href="/partner/profile"
+                  onClick={() => setUserMenuOpen(false)}
+                  className="flex items-center gap-3 px-3 py-2.5 text-sm text-[#a3a3a3] hover:bg-[#1a1a1a] hover:text-[#ededed] transition-colors"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                  </svg>
+                  プロフィール設定
+                </Link>
+              </div>
+              <hr className="border-[rgba(255,255,255,0.06)]" />
+              <div className="py-1">
+                <button
+                  onClick={() => { if (confirm('ログアウトしますか？')) signOut({ callbackUrl: '/partner/login' }) }}
+                  className="flex items-center gap-3 px-3 py-2.5 w-full text-sm text-[#a3a3a3] hover:bg-[#1a1a1a] hover:text-[#ededed] transition-colors"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
+                  </svg>
+                  ログアウト
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* トグルボタン */}
           <button
-            onClick={() => { if (confirm('ログアウトしますか？')) signOut({ callbackUrl: '/partner/login' }) }}
-            className="mt-2 text-xs text-[#a3a3a3] hover:text-white"
+            onClick={() => setUserMenuOpen(!userMenuOpen)}
+            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-[#1a1a1a] transition-colors"
           >
-            ログアウト
+            <div className="w-9 h-9 rounded-full bg-white text-black flex items-center justify-center shrink-0 text-sm font-semibold">
+              {user?.name?.[0] ?? '?'}
+            </div>
+            <div className="min-w-0 flex-1 text-left">
+              <p className="text-sm font-medium text-[#ededed] truncate">{user?.name ?? 'パートナー'}</p>
+              <p className="text-[10px] text-[#666] truncate">{user?.email ?? ''}</p>
+            </div>
+            <svg className={`w-4 h-4 text-[#666] shrink-0 transition-transform ${userMenuOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l4-4 4 4" />
+            </svg>
           </button>
         </div>
       </aside>
+
       <main className="flex-1 min-w-0">
         {children}
       </main>

--- a/src/app/(partner)/partner/members/page.tsx
+++ b/src/app/(partner)/partner/members/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { format } from 'date-fns'
+import { ja } from 'date-fns/locale'
+
+type Member = {
+  id: string
+  name: string
+  email: string
+  acceptedAt: string | null
+  createdAt: string
+  isMe: boolean
+}
+
+export default function PartnerMembersPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [members, setMembers] = useState<Member[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/partner/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    fetch('/api/partner/partners')
+      .then(r => r.ok ? r.json() : [])
+      .then(setMembers)
+      .finally(() => setLoading(false))
+  }, [status])
+
+  if (status !== 'authenticated') return null
+
+  return (
+    <div className="px-6 py-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-1">参加メンバー</h1>
+      <p className="text-sm text-[#a3a3a3] mb-6">この画面にログイン中のセールスパートナー一覧（{members.length} 名）</p>
+
+      {loading ? (
+        <p className="text-sm text-[#a3a3a3]">読み込み中…</p>
+      ) : members.length === 0 ? (
+        <p className="text-sm text-[#a3a3a3]">メンバーはまだいません</p>
+      ) : (
+        <div className="space-y-2">
+          {members.map(m => (
+            <div
+              key={m.id}
+              className={`flex items-center gap-3 p-4 rounded-2xl border ${
+                m.isMe
+                  ? 'bg-[#141414] border-amber-500/30'
+                  : 'bg-[#141414] border-[rgba(255,255,255,0.06)]'
+              }`}
+            >
+              <div className="w-10 h-10 rounded-full bg-[#1a1a1a] flex items-center justify-center text-sm font-bold">
+                {m.name.slice(0, 1)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold truncate">
+                  {m.name}
+                  {m.isMe && <span className="ml-2 text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-300">あなた</span>}
+                </p>
+                <p className="text-[11px] text-[#666] truncate">{m.email}</p>
+              </div>
+              <p className="text-[11px] text-[#666] flex-shrink-0 hidden sm:block">
+                {m.acceptedAt ? format(new Date(m.acceptedAt), 'yyyy/M/d 参加', { locale: ja }) : '招待中'}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(partner)/partner/profile/page.tsx
+++ b/src/app/(partner)/partner/profile/page.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+
+type Profile = {
+  id: string
+  name: string
+  email: string
+  isActive: boolean
+  acceptedAt: string | null
+  createdAt: string
+}
+
+export default function PartnerProfilePage() {
+  const { data: session, status, update } = useSession()
+  const router = useRouter()
+
+  const [loading, setLoading] = useState(true)
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [msg, setMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [savingBasic, setSavingBasic] = useState(false)
+
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [savingPassword, setSavingPassword] = useState(false)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/partner/login')
+  }, [status, router])
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    fetch('/api/partner/me')
+      .then(r => r.ok ? r.json() : null)
+      .then((p: Profile | null) => {
+        if (!p) return
+        setProfile(p)
+        setName(p.name)
+        setEmail(p.email)
+      })
+      .finally(() => setLoading(false))
+  }, [status])
+
+  function flash(kind: 'success' | 'error', text: string) {
+    setMsg({ kind, text })
+    setTimeout(() => setMsg(null), 3000)
+  }
+
+  async function saveBasic() {
+    setSavingBasic(true)
+    const res = await fetch('/api/partner/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email }),
+    })
+    setSavingBasic(false)
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      flash('error', data.error ?? '保存に失敗しました')
+      return
+    }
+    flash('success', 'プロフィールを更新しました')
+    setProfile(data)
+    // セッションにも反映
+    await update({ name: data.name, email: data.email })
+  }
+
+  async function savePassword() {
+    if (newPassword !== confirmPassword) {
+      flash('error', '新しいパスワードと確認用パスワードが一致しません')
+      return
+    }
+    if (newPassword.length < 8) {
+      flash('error', 'パスワードは8文字以上で設定してください')
+      return
+    }
+    setSavingPassword(true)
+    const res = await fetch('/api/partner/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentPassword, newPassword }),
+    })
+    setSavingPassword(false)
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      flash('error', data.error ?? 'パスワードの変更に失敗しました')
+      return
+    }
+    flash('success', 'パスワードを変更しました')
+    setCurrentPassword(''); setNewPassword(''); setConfirmPassword('')
+  }
+
+  if (status !== 'authenticated' || loading || !profile) {
+    return <p className="px-6 py-8 text-sm text-[#a3a3a3]">読み込み中…</p>
+  }
+
+  return (
+    <div className="px-6 py-8 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">プロフィール設定</h1>
+
+      {msg && (
+        <div className={`mb-4 px-3 py-2 rounded text-xs ${msg.kind === 'success' ? 'bg-emerald-500/15 text-emerald-300' : 'bg-rose-500/15 text-rose-300'}`}>{msg.text}</div>
+      )}
+
+      <section className="bg-[#141414] rounded-2xl p-5 border border-[rgba(255,255,255,0.06)] mb-5">
+        <h2 className="text-base font-bold mb-3">基本情報</h2>
+        <div className="space-y-3">
+          <label className="block">
+            <span className="block text-xs text-[#a3a3a3] mb-1">お名前</span>
+            <input value={name} onChange={e => setName(e.target.value)} className="w-full px-3 py-2 rounded-md bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-sm" />
+          </label>
+          <label className="block">
+            <span className="block text-xs text-[#a3a3a3] mb-1">メールアドレス</span>
+            <input type="email" value={email} onChange={e => setEmail(e.target.value)} className="w-full px-3 py-2 rounded-md bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-sm" />
+          </label>
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={saveBasic} disabled={savingBasic} className="px-4 py-2 rounded-md bg-white text-black text-sm font-semibold disabled:opacity-50">
+            {savingBasic ? '保存中…' : '保存'}
+          </button>
+        </div>
+      </section>
+
+      <section className="bg-[#141414] rounded-2xl p-5 border border-[rgba(255,255,255,0.06)]">
+        <h2 className="text-base font-bold mb-3">パスワード変更</h2>
+        <div className="space-y-3">
+          <label className="block">
+            <span className="block text-xs text-[#a3a3a3] mb-1">現在のパスワード</span>
+            <input type="password" value={currentPassword} onChange={e => setCurrentPassword(e.target.value)} className="w-full px-3 py-2 rounded-md bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-sm" />
+          </label>
+          <label className="block">
+            <span className="block text-xs text-[#a3a3a3] mb-1">新しいパスワード（8文字以上）</span>
+            <input type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} className="w-full px-3 py-2 rounded-md bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-sm" />
+          </label>
+          <label className="block">
+            <span className="block text-xs text-[#a3a3a3] mb-1">新しいパスワード（確認）</span>
+            <input type="password" value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} className="w-full px-3 py-2 rounded-md bg-[#1a1a1a] border border-[rgba(255,255,255,0.08)] text-sm" />
+          </label>
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={savePassword} disabled={savingPassword || !currentPassword || !newPassword} className="px-4 py-2 rounded-md bg-white text-black text-sm font-semibold disabled:opacity-50">
+            {savingPassword ? '変更中…' : 'パスワードを変更'}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/api/partner/me/route.ts
+++ b/src/app/api/partner/me/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
+import { prisma } from '@/lib/prisma'
+import { requirePartner } from '@/lib/partner-auth'
+import { z } from 'zod'
+
+/** ログイン中パートナーの情報取得 */
+export async function GET() {
+  const user = await requirePartner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const partner = await prisma.salesPartner.findUnique({
+    where: { id: user.id },
+    select: {
+      id: true, name: true, email: true, isActive: true,
+      acceptedAt: true, createdAt: true, updatedAt: true,
+    },
+  })
+  if (!partner) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(partner)
+}
+
+const profileSchema = z.object({
+  name:        z.string().min(1).max(100).optional(),
+  email:       z.string().email().optional(),
+  currentPassword: z.string().optional(),
+  newPassword: z.string().min(8).max(128).optional(),
+})
+
+/** プロフィール更新（氏名・メール・パスワード） */
+export async function PATCH(req: NextRequest) {
+  const user = await requirePartner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await req.json()
+  const parsed = profileSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'バリデーションエラー' }, { status: 400 })
+  }
+  const { name, email, currentPassword, newPassword } = parsed.data
+
+  const partner = await prisma.salesPartner.findUnique({ where: { id: user.id } })
+  if (!partner) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const data: any = {}
+  if (name !== undefined) data.name = name
+  if (email !== undefined && email !== partner.email) {
+    const existing = await prisma.salesPartner.findUnique({ where: { email } })
+    if (existing && existing.id !== partner.id) {
+      return NextResponse.json({ error: 'このメールアドレスは既に使用されています' }, { status: 409 })
+    }
+    data.email = email
+  }
+
+  if (newPassword) {
+    if (!currentPassword || !partner.password) {
+      return NextResponse.json({ error: '現在のパスワードを入力してください' }, { status: 400 })
+    }
+    const valid = await bcrypt.compare(currentPassword, partner.password)
+    if (!valid) return NextResponse.json({ error: '現在のパスワードが正しくありません' }, { status: 400 })
+    data.password = await bcrypt.hash(newPassword, 10)
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: '更新項目がありません' }, { status: 400 })
+  }
+
+  const updated = await prisma.salesPartner.update({
+    where: { id: partner.id },
+    data,
+    select: {
+      id: true, name: true, email: true, isActive: true,
+      acceptedAt: true, createdAt: true, updatedAt: true,
+    },
+  })
+  return NextResponse.json(updated)
+}

--- a/src/app/api/partner/partners/route.ts
+++ b/src/app/api/partner/partners/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requirePartner } from '@/lib/partner-auth'
+
+/** セールスパートナー一覧（ログイン中の全パートナーから閲覧可。
+ *  パスワードなど機密情報は返さない。） */
+export async function GET() {
+  const user = await requirePartner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const partners = await prisma.salesPartner.findMany({
+    where: { isActive: true, acceptedAt: { not: null } },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      acceptedAt: true,
+      createdAt: true,
+    },
+    orderBy: { acceptedAt: 'desc' },
+  })
+
+  return NextResponse.json(partners.map(p => ({ ...p, isMe: p.id === user.id })))
+}


### PR DESCRIPTION
## 概要
セールスパートナー専用画面のサイドバー下部を、管理ポータルと同じ折りたたみ式ユーザーメニューに刷新。自分のプロフィール編集と、画面に参加中のメンバー一覧閲覧機能を追加する。

## 変更内容

### UI
- **[src/app/(partner)/layout.tsx](src/app/(partner)/layout.tsx)** — サイドバー下部を折りたたみ式に。アバター+氏名クリックで「プロフィール設定」「ログアウト」のポップアップ表示
- **/partner/profile** (新規) — 氏名・メールの編集、現在/新パスワードによるパスワード変更
- **/partner/members** (新規) — 画面に参加中のパートナー一覧（自分は「あなた」バッジ付き）
- ナビに「参加メンバー」を追加

### API
- **GET/PATCH /api/partner/me** — 自己プロフィールの取得・更新（氏名/メール/パスワード）
  - パスワード変更時は現在のパスワード検証必須
  - メール重複は 409
- **GET /api/partner/partners** — アクティブなパートナー一覧（パスワード等の機密フィールドは返さない）

## Test plan
- [ ] パートナーログイン後、サイドバー下部にアバター+氏名表示。クリックでポップアップ表示
- [ ] 「プロフィール設定」から氏名/メールを変更 → 保存後セッションにも反映
- [ ] パスワード変更（現在のパスワード必須、確認用パスワード一致チェック）
- [ ] 「参加メンバー」で全パートナーを確認、自分のレコードに「あなた」バッジ
- [ ] 「ログアウト」で /partner/login へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)