### PR TITLE
店舗ページにクレジットカード登録（Stripe）機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@auth/prisma-adapter": "^2.11.1",
         "@google/generative-ai": "^0.24.1",
         "@prisma/client": "^5.22.0",
+        "@stripe/react-stripe-js": "^6.3.0",
+        "@stripe/stripe-js": "^9.4.0",
         "@tiptap/extension-image": "^3.20.4",
         "@tiptap/extension-link": "^3.20.4",
         "@tiptap/extension-placeholder": "^3.20.4",
@@ -41,6 +43,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "^3.8.0",
+        "stripe": "^22.1.1",
         "three": "^0.183.2",
         "uuid": "^13.0.0",
         "zod": "^4.3.6"
@@ -1462,6 +1465,29 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.3.0.tgz",
+      "integrity": "sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.3.1 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.4.0.tgz",
+      "integrity": "sha512-zXG86DnoLU5nH2U18tX5ApTE3IAm+txoiPm4YFyEtRS0K5y7ZDH9M8e1Le/cZyI6wvW3BkJn2daZe2FqZOrSSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -5786,8 +5812,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -6230,7 +6255,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6596,7 +6620,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7003,7 +7026,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7297,8 +7319,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -8057,6 +8078,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@auth/prisma-adapter": "^2.11.1",
     "@google/generative-ai": "^0.24.1",
     "@prisma/client": "^5.22.0",
+    "@stripe/react-stripe-js": "^6.3.0",
+    "@stripe/stripe-js": "^9.4.0",
     "@tiptap/extension-image": "^3.20.4",
     "@tiptap/extension-link": "^3.20.4",
     "@tiptap/extension-placeholder": "^3.20.4",
@@ -42,6 +44,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.8.0",
+    "stripe": "^22.1.1",
     "three": "^0.183.2",
     "uuid": "^13.0.0",
     "zod": "^4.3.6"

--- a/prisma/migrations/20260511110000_add_store_stripe_customer_id/migration.sql
+++ b/prisma/migrations/20260511110000_add_store_stripe_customer_id/migration.sql
@@ -1,0 +1,3 @@
+-- Store.stripeCustomerId 追加
+ALTER TABLE "Store" ADD COLUMN "stripeCustomerId" TEXT;
+CREATE UNIQUE INDEX "Store_stripeCustomerId_key" ON "Store"("stripeCustomerId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Store {
   businessHoursStart  String?   @default("10:00") // 営業開始時間
   businessHoursEnd    String?   @default("19:00") // 営業終了時間
   businessDays        String?   @default("[0,1,2,3,4,5,6]") // 営業曜日 JSON配列 (0=日,1=月,...6=土)
+  stripeCustomerId    String?   @unique  // Stripe Customer ID（カード情報のオーナー識別子）
   customers  User[]
   visitSchedules VisitSchedule[]
   visitRequests  VisitRequest[]

--- a/src/app/(store)/store/payment/page.tsx
+++ b/src/app/(store)/store/payment/page.tsx
@@ -1,0 +1,295 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { loadStripe, Stripe as StripeJs } from '@stripe/stripe-js'
+import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+type PaymentMethod = {
+  id: string
+  brand: string | null
+  last4: string | null
+  expMonth: number | null
+  expYear: number | null
+  created: number
+}
+
+type ListResponse = {
+  stripeConfigured: boolean
+  paymentMethods: PaymentMethod[]
+  defaultPaymentMethodId: string | null
+}
+
+const BRAND_LABEL: Record<string, string> = {
+  visa: 'Visa',
+  mastercard: 'Mastercard',
+  amex: 'American Express',
+  jcb: 'JCB',
+  discover: 'Discover',
+  diners: 'Diners Club',
+  unionpay: 'UnionPay',
+}
+
+export default function StorePaymentPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const sessionUser = session?.user as any
+  const isSubAccount = !!sessionUser?.isSubAccount
+
+  const [data, setData] = useState<ListResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [msg, setMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [setupClientSecret, setSetupClientSecret] = useState('')
+  const [stripePromise, setStripePromise] = useState<Promise<StripeJs | null> | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/store/login')
+  }, [status, router])
+
+  function load() {
+    fetch('/api/store/payment/payment-methods')
+      .then(r => r.json())
+      .then((d: ListResponse) => {
+        setData(d)
+        if (!d.stripeConfigured) {
+          setError('Stripeが未設定です。管理者にお問い合わせください。')
+        }
+      })
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    if (status === 'authenticated' && !isSubAccount) load()
+  }, [status, isSubAccount])
+
+  function flash(kind: 'success' | 'error', text: string) {
+    setMsg({ kind, text })
+    setTimeout(() => setMsg(null), 3000)
+  }
+
+  async function startAdd() {
+    setError('')
+    setShowAddForm(true)
+    const res = await fetch('/api/store/payment/setup-intent', { method: 'POST' })
+    const j = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      setError(j.error ?? 'カード登録の準備に失敗しました')
+      setShowAddForm(false)
+      return
+    }
+    if (!j.publishableKey) {
+      setError('STRIPE 公開キーが未設定です')
+      setShowAddForm(false)
+      return
+    }
+    setStripePromise(loadStripe(j.publishableKey))
+    setSetupClientSecret(j.clientSecret)
+  }
+
+  async function handleDelete(pmId: string) {
+    if (!confirm('このカードを削除しますか？')) return
+    setBusyId(pmId)
+    const res = await fetch(`/api/store/payment/payment-methods/${pmId}`, { method: 'DELETE' })
+    setBusyId(null)
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}))
+      flash('error', j.error ?? '削除に失敗しました')
+      return
+    }
+    flash('success', 'カードを削除しました')
+    load()
+  }
+
+  async function handleSetDefault(pmId: string) {
+    setBusyId(pmId)
+    const res = await fetch(`/api/store/payment/payment-methods/${pmId}/default`, { method: 'POST' })
+    setBusyId(null)
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}))
+      flash('error', j.error ?? '設定に失敗しました')
+      return
+    }
+    flash('success', 'デフォルトカードを変更しました')
+    load()
+  }
+
+  if (status !== 'authenticated') return null
+  if (isSubAccount) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <p className="text-sm text-[var(--md-sys-color-on-surface-variant)]">
+          決済情報の管理は店舗オーナーのみご利用いただけます。サブアカウントでは表示できません。
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6">
+      <h1 className="text-xl font-bold text-[var(--md-sys-color-on-surface)] mb-1">決済情報</h1>
+      <p className="text-sm text-[var(--md-sys-color-on-surface-variant)] mb-6">
+        システム利用料・備品購入などに使用するクレジットカードを登録します。カード情報は Stripe で安全に保管されます。
+      </p>
+
+      {error && (
+        <div className="mb-4 px-3 py-2 rounded text-xs bg-rose-500/10 text-rose-500 border border-rose-500/30">{error}</div>
+      )}
+      {msg && (
+        <div className={`mb-4 px-3 py-2 rounded text-xs ${
+          msg.kind === 'success'
+            ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/30'
+            : 'bg-rose-500/10 text-rose-500 border border-rose-500/30'
+        }`}>{msg.text}</div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-10"><LoadingSpinner /></div>
+      ) : (
+        <>
+          {/* カード一覧 */}
+          <div className="space-y-2 mb-4">
+            {data && data.paymentMethods.length === 0 ? (
+              <div className="text-sm text-[var(--md-sys-color-on-surface-variant)] px-4 py-6 rounded-xl border border-dashed border-[var(--md-sys-color-outline-variant)] text-center">
+                まだカードが登録されていません
+              </div>
+            ) : (
+              data?.paymentMethods.map(pm => {
+                const isDefault = pm.id === data.defaultPaymentMethodId
+                return (
+                  <div
+                    key={pm.id}
+                    className={`flex items-center gap-3 p-4 rounded-2xl border ${
+                      isDefault
+                        ? 'border-emerald-500/50 bg-emerald-500/5'
+                        : 'border-[var(--md-sys-color-outline-variant)] bg-[var(--md-sys-color-surface-container-low)]'
+                    }`}
+                  >
+                    <div className="w-10 h-10 rounded-md bg-[var(--md-sys-color-surface-container-high)] flex items-center justify-center text-xs font-bold">
+                      {pm.brand?.slice(0, 2).toUpperCase() ?? '——'}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold">
+                        {pm.brand ? (BRAND_LABEL[pm.brand] ?? pm.brand) : 'カード'} ····{pm.last4 ?? '????'}
+                        {isDefault && <span className="ml-2 text-[10px] font-bold px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">デフォルト</span>}
+                      </p>
+                      <p className="text-[11px] text-[var(--md-sys-color-on-surface-variant)]">
+                        有効期限 {pm.expMonth?.toString().padStart(2, '0')}/{pm.expYear}
+                      </p>
+                    </div>
+                    {!isDefault && (
+                      <button
+                        onClick={() => handleSetDefault(pm.id)}
+                        disabled={busyId === pm.id}
+                        className="text-xs px-2 py-1 rounded text-[var(--md-sys-color-primary)] hover:underline disabled:opacity-50"
+                      >
+                        デフォルトに
+                      </button>
+                    )}
+                    <button
+                      onClick={() => handleDelete(pm.id)}
+                      disabled={busyId === pm.id}
+                      className="text-xs px-2 py-1 rounded text-rose-500 hover:underline disabled:opacity-50"
+                    >
+                      削除
+                    </button>
+                  </div>
+                )
+              })
+            )}
+          </div>
+
+          {/* 追加ボタン */}
+          {data?.stripeConfigured && !showAddForm && (
+            <button
+              onClick={startAdd}
+              className="w-full py-3 rounded-xl bg-[var(--store-primary)] text-[var(--store-on-primary)] text-sm font-semibold hover:opacity-90"
+            >
+              + 新しいカードを登録
+            </button>
+          )}
+
+          {/* 追加フォーム（Stripe Elements） */}
+          {showAddForm && setupClientSecret && stripePromise && (
+            <div className="mt-4 p-5 rounded-2xl border border-[var(--md-sys-color-outline-variant)] bg-[var(--md-sys-color-surface-container-low)]">
+              <h2 className="text-base font-bold mb-3">カードを登録</h2>
+              <Elements
+                stripe={stripePromise}
+                options={{
+                  clientSecret: setupClientSecret,
+                  appearance: { theme: 'stripe' },
+                  locale: 'ja',
+                }}
+              >
+                <AddCardForm
+                  onSuccess={() => {
+                    setShowAddForm(false)
+                    setSetupClientSecret('')
+                    flash('success', 'カードを登録しました')
+                    load()
+                  }}
+                  onCancel={() => { setShowAddForm(false); setSetupClientSecret('') }}
+                />
+              </Elements>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function AddCardForm({ onSuccess, onCancel }: { onSuccess: () => void; onCancel: () => void }) {
+  const stripe = useStripe()
+  const elements = useElements()
+  const [submitting, setSubmitting] = useState(false)
+  const [err, setErr] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!stripe || !elements) return
+    setSubmitting(true)
+    setErr('')
+    const { error } = await stripe.confirmSetup({
+      elements,
+      confirmParams: {
+        return_url: typeof window !== 'undefined' ? `${window.location.origin}/store/payment` : '',
+      },
+      redirect: 'if_required',
+    })
+    setSubmitting(false)
+    if (error) {
+      setErr(error.message ?? 'カード登録に失敗しました')
+      return
+    }
+    onSuccess()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <PaymentElement />
+      {err && <p className="text-xs text-rose-500">{err}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={submitting}
+          className="px-4 py-2 rounded-md border border-[var(--md-sys-color-outline)] text-sm"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={submitting || !stripe}
+          className="px-4 py-2 rounded-md bg-[var(--store-primary)] text-[var(--store-on-primary)] text-sm font-semibold disabled:opacity-50"
+        >
+          {submitting ? '登録中…' : 'カードを登録'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/app/api/store/payment/payment-methods/[id]/default/route.ts
+++ b/src/app/api/store/payment/payment-methods/[id]/default/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireStoreOwner } from '@/lib/store-auth'
+import { isStripeConfigured, requireStripe } from '@/lib/stripe'
+
+/** デフォルトカードに設定（invoice_settings.default_payment_method） */
+export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireStoreOwner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!isStripeConfigured()) return NextResponse.json({ error: 'Stripe が未設定です' }, { status: 503 })
+
+  const { id } = await ctx.params
+  const store = await prisma.store.findUnique({
+    where: { id: user.id },
+    select: { stripeCustomerId: true },
+  })
+  if (!store?.stripeCustomerId) {
+    return NextResponse.json({ error: '登録カードがありません' }, { status: 404 })
+  }
+
+  const stripe = requireStripe()
+  const method = await stripe.paymentMethods.retrieve(id)
+  if (typeof method.customer !== 'string' || method.customer !== store.stripeCustomerId) {
+    return NextResponse.json({ error: '権限がありません' }, { status: 403 })
+  }
+
+  await stripe.customers.update(store.stripeCustomerId, {
+    invoice_settings: { default_payment_method: id },
+  })
+
+  return NextResponse.json({ ok: true, defaultPaymentMethodId: id })
+}

--- a/src/app/api/store/payment/payment-methods/[id]/route.ts
+++ b/src/app/api/store/payment/payment-methods/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireStoreOwner } from '@/lib/store-auth'
+import { isStripeConfigured, requireStripe } from '@/lib/stripe'
+
+/** カード削除（detach） */
+export async function DELETE(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const user = await requireStoreOwner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!isStripeConfigured()) return NextResponse.json({ error: 'Stripe が未設定です' }, { status: 503 })
+
+  const { id } = await ctx.params
+  const store = await prisma.store.findUnique({
+    where: { id: user.id },
+    select: { stripeCustomerId: true },
+  })
+  if (!store?.stripeCustomerId) {
+    return NextResponse.json({ error: '登録カードがありません' }, { status: 404 })
+  }
+
+  const stripe = requireStripe()
+  // 当該カードがこの店舗のものか確認
+  const method = await stripe.paymentMethods.retrieve(id)
+  if (typeof method.customer !== 'string' || method.customer !== store.stripeCustomerId) {
+    return NextResponse.json({ error: '権限がありません' }, { status: 403 })
+  }
+
+  await stripe.paymentMethods.detach(id)
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/store/payment/payment-methods/route.ts
+++ b/src/app/api/store/payment/payment-methods/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireStoreOwner } from '@/lib/store-auth'
+import { isStripeConfigured, requireStripe } from '@/lib/stripe'
+
+/** 登録済みカード一覧 + デフォルトカードを返す */
+export async function GET() {
+  const user = await requireStoreOwner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Stripe 未設定の場合は空の一覧を返す（UI は「未設定」表示）
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ stripeConfigured: false, paymentMethods: [], defaultPaymentMethodId: null })
+  }
+
+  const store = await prisma.store.findUnique({
+    where: { id: user.id },
+    select: { stripeCustomerId: true },
+  })
+  if (!store?.stripeCustomerId) {
+    return NextResponse.json({ stripeConfigured: true, paymentMethods: [], defaultPaymentMethodId: null })
+  }
+
+  const stripe = requireStripe()
+  const [methods, customer] = await Promise.all([
+    stripe.paymentMethods.list({ customer: store.stripeCustomerId, type: 'card' }),
+    stripe.customers.retrieve(store.stripeCustomerId),
+  ])
+
+  let defaultPaymentMethodId: string | null = null
+  if (customer && !customer.deleted) {
+    const c = customer as import('stripe').Stripe.Customer
+    const dpm = c.invoice_settings?.default_payment_method
+    defaultPaymentMethodId = typeof dpm === 'string' ? dpm : dpm?.id ?? null
+  }
+
+  return NextResponse.json({
+    stripeConfigured: true,
+    defaultPaymentMethodId,
+    paymentMethods: methods.data.map(m => ({
+      id: m.id,
+      brand: m.card?.brand ?? null,
+      last4: m.card?.last4 ?? null,
+      expMonth: m.card?.exp_month ?? null,
+      expYear: m.card?.exp_year ?? null,
+      created: m.created,
+    })),
+  })
+}

--- a/src/app/api/store/payment/setup-intent/route.ts
+++ b/src/app/api/store/payment/setup-intent/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { requireStoreOwner } from '@/lib/store-auth'
+import { isStripeConfigured, requireStripe } from '@/lib/stripe'
+import { ensureStoreStripeCustomer } from '@/lib/store-stripe'
+
+/** カード登録用の SetupIntent を作成し、clientSecret を返す */
+export async function POST() {
+  const user = await requireStoreOwner()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: 'Stripe が未設定です（管理者にお問い合わせください）' }, { status: 503 })
+  }
+
+  const stripe = requireStripe()
+  const customerId = await ensureStoreStripeCustomer(user.id)
+  const intent = await stripe.setupIntents.create({
+    customer: customerId,
+    payment_method_types: ['card'],
+    usage: 'off_session',
+  })
+
+  return NextResponse.json({
+    clientSecret: intent.client_secret,
+    customerId,
+    publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? null,
+  })
+}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -132,6 +132,15 @@ const menuNavItems = [
     ),
   },
   {
+    href: '/store/payment',
+    label: '決済情報',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
+      </svg>
+    ),
+  },
+  {
     href: '/store/mystore',
     label: '店舗情報',
     icon: (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -147,6 +147,7 @@ export const authOptions: NextAuthOptions = {
               name: member.name,
               avatar: member.avatar || null,
               role: 'store' as const,
+              isSubAccount: true,
             }
           }
         }
@@ -288,6 +289,7 @@ export const authOptions: NextAuthOptions = {
         token.avatar = (user as any).avatar ?? null
         token.customerType = (user as any).customerType ?? null
         token.customerTypes = (user as any).customerTypes ?? null
+        token.isSubAccount = (user as any).isSubAccount ?? false
       }
       // クライアントから update() が呼ばれたときにトークンを更新
       if (trigger === 'update' && updatedSession) {
@@ -319,6 +321,7 @@ export const authOptions: NextAuthOptions = {
         ;(session.user as any).avatar = token.avatar ?? null
         ;(session.user as any).customerType = token.customerType ?? null
         ;(session.user as any).customerTypes = token.customerTypes ?? null
+        ;(session.user as any).isSubAccount = (token as any).isSubAccount ?? false
         if (token.name) session.user.name = token.name as string
         if (token.email) session.user.email = token.email as string
       }

--- a/src/lib/store-auth.ts
+++ b/src/lib/store-auth.ts
@@ -1,0 +1,31 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+export type StoreUser = {
+  id: string
+  email: string | null
+  name: string | null
+  /** サブアカウントかどうか（StoreMember）。決済機能などは false の店舗本人のみに許可する */
+  isSubAccount?: boolean
+}
+
+/** 店舗ロールでログインしているか確認 */
+export async function requireStore(): Promise<StoreUser | null> {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as any
+  if (!session || user?.role !== 'store') return null
+  return {
+    id: user.id,
+    email: user.email ?? null,
+    name: user.name ?? null,
+    isSubAccount: !!user.isSubAccount,
+  }
+}
+
+/** 店舗本人のみ許可（サブアカウント禁止）。決済まわりはこちらを使う。 */
+export async function requireStoreOwner(): Promise<StoreUser | null> {
+  const user = await requireStore()
+  if (!user) return null
+  if (user.isSubAccount) return null
+  return user
+}

--- a/src/lib/store-stripe.ts
+++ b/src/lib/store-stripe.ts
@@ -1,0 +1,34 @@
+import { prisma } from '@/lib/prisma'
+import { requireStripe } from '@/lib/stripe'
+
+/**
+ * Store が Stripe Customer を未だ持っていなければ作成し、stripeCustomerId を保存する。
+ * 既存の Customer がある場合はその ID を返す。サブアカウント（StoreMember）からは呼ばない前提。
+ */
+export async function ensureStoreStripeCustomer(storeId: string): Promise<string> {
+  const stripe = requireStripe()
+  const store = await prisma.store.findUnique({
+    where: { id: storeId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      stripeCustomerId: true,
+    },
+  })
+  if (!store) throw new Error('店舗が見つかりません')
+  if (store.stripeCustomerId) return store.stripeCustomerId
+
+  const customer = await stripe.customers.create({
+    name: store.name,
+    email: store.email ?? undefined,
+    metadata: { storeId: store.id },
+  })
+
+  await prisma.store.update({
+    where: { id: store.id },
+    data: { stripeCustomerId: customer.id },
+  })
+
+  return customer.id
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,30 @@
+import Stripe from 'stripe'
+
+/**
+ * Stripe サーバーサイドクライアント。
+ *
+ * 環境変数:
+ * - STRIPE_SECRET_KEY: テストは sk_test_*, 本番は sk_live_*
+ * - NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: フロントで使う（pk_test_* / pk_live_*）
+ *
+ * Vercel の Environment Variables に両方を設定してください。
+ */
+const secretKey = process.env.STRIPE_SECRET_KEY
+
+export const stripe = secretKey
+  ? new Stripe(secretKey, {
+      // SDK 既定の最新版を使う。明示しないことでマイナーアップデートに追従。
+      typescript: true,
+    })
+  : null
+
+export function isStripeConfigured(): boolean {
+  return !!secretKey
+}
+
+export function requireStripe(): Stripe {
+  if (!stripe) {
+    throw new Error('STRIPE_SECRET_KEY が未設定です。Vercel の環境変数を確認してください。')
+  }
+  return stripe
+}


### PR DESCRIPTION
## 概要
店舗オーナーが自店舗にクレジットカードを登録できる機能を追加します。カード情報は Stripe で安全に保管され、システム利用料・備品購入などの今後の課金に使用します。

## 重要: マージ前に Vercel 環境変数を設定してください
Vercel > Settings > Environment Variables に以下を追加:
- **STRIPE_SECRET_KEY** = `sk_test_...`（Stripe ダッシュボード > Developers > API keys から取得）
- **NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY** = `pk_test_...`

未設定でもデプロイは成功しますが、`/store/payment` で「Stripeが未設定です」と表示されます。

## 変更内容

### Prisma
- `Store.stripeCustomerId String? @unique` — Stripe Customer ID 紐付け
- マイグレーション SQL 同梱

### API
- **POST `/api/store/payment/setup-intent`** — SetupIntent を作成し clientSecret + publishableKey を返す。Customer が未作成なら同時に作成
- **GET `/api/store/payment/payment-methods`** — 登録カード一覧 + デフォルトカード ID
- **DELETE `/api/store/payment/payment-methods/[id]`** — カード detach（削除）
- **POST `/api/store/payment/payment-methods/[id]/default`** — デフォルトカード設定

### 認可
- 新規 `requireStoreOwner` — `role=store` かつ `isSubAccount=false`（StoreMember は決済機能を利用不可）
- `auth.ts` の JWT に `isSubAccount` を追加（StoreMember ログイン時 true）

### UI
- `/store/payment` — Stripe Elements でカード追加、一覧、削除、デフォルト設定
- 店舗 BottomNav に「決済情報」リンク追加

### npm パッケージ
- `stripe`（サーバー）
- `@stripe/stripe-js`、`@stripe/react-stripe-js`（クライアント）

## Test plan
- [ ] 店舗オーナーで `/store/payment` を開く → 「カードが登録されていません」表示
- [ ] 「+ 新しいカードを登録」 → Stripe Elements 表示、テストカード `4242 4242 4242 4242` で登録
- [ ] 一覧にカードが表示、「デフォルト」バッジ
- [ ] 2 枚目を登録 → 「デフォルトに」ボタンで切り替え
- [ ] 「削除」でカード除外
- [ ] StoreMember（サブアカウント）でログイン → `/store/payment` は「店舗オーナーのみ」メッセージ表示
- [ ] STRIPE_SECRET_KEY 未設定環境では 503 を返し UI で「未設定」と案内

🤖 Generated with [Claude Code](https://claude.com/claude-code)