### PR TITLE
宅配買取の送付登録画面にクーリングオフ対象外の注意書きを追加

### DIFF
--- a/src/app/(customer)/mypage/page.tsx
+++ b/src/app/(customer)/mypage/page.tsx
@@ -2316,6 +2316,15 @@ function MyPageContent() {
                   </svg>
                   注意事項
                 </h3>
+
+                {/* クーリングオフ対象外 */}
+                <div className="mb-3 px-3 py-2 rounded-md bg-amber-100/70 border border-amber-300/70">
+                  <p className="text-xs font-bold text-amber-900">宅配買取はクーリングオフ制度の対象外です</p>
+                  <p className="text-[11px] text-amber-800 mt-0.5 leading-relaxed">
+                    特定商取引法上、お客様ご自身で商品を送付いただく宅配買取は「訪問購入」に該当しないため、契約後の解除（クーリングオフ）はできません。送付前に内容をご確認ください。
+                  </p>
+                </div>
+
                 <p className="text-xs text-amber-700 mb-2">以下のようなものは箱に入れていただくことができません。</p>
                 <ul className="text-xs text-amber-700 space-y-1 list-disc list-inside">
                   <li>当社規定の「<button type="button" onClick={() => setShowWorthlessModal(true)} className="text-[#B91C1C] underline font-medium hover:text-red-700">無価値</button>」となる商品</li>


### PR DESCRIPTION
## 概要
宅配買取顧客が送付登録を行う際の注意事項エリアに、**「宅配買取はクーリングオフ制度の対象外」** であることを明示。

## 法的根拠
特定商取引法上、お客様自身が商品を送付する宅配買取は「訪問購入」に該当しないため、契約後の解除（クーリングオフ）はできません。事業者として送付前に明示しておく必要があるため、既存の「箱に入れられないもの」リストの上部にハイライト表示。

## 変更内容
- [src/app/(customer)/mypage/page.tsx](src/app/(customer)/mypage/page.tsx) — 送付一覧タブの注意事項カード内に、目立つ枠線付きで案内文を追加

## Test plan
- [ ] 宅配買取顧客で /mypage を開き「送付」タブへ
- [ ] 注意事項カードの上部に「宅配買取はクーリングオフ制度の対象外です」のハイライト表示を確認
- [ ] 既存の「無価値」リンクや「返送する場合があります」の文言が引き続き機能

🤖 Generated with [Claude Code](https://claude.com/claude-code)