### PR TITLE
セールスパートナー画面のサイドバーをスクロール追従させない（sticky）

### DIFF
--- a/src/app/(partner)/layout.tsx
+++ b/src/app/(partner)/layout.tsx
@@ -36,7 +36,7 @@ export default function PartnerLayout({ children }: { children: React.ReactNode 
 
   return (
     <div data-portal="partner" className="flex min-h-screen bg-[#0f1115] text-[#ededed]">
-      <aside className="hidden lg:flex w-60 flex-col bg-[#0a0a0a] shadow-[inset_-1px_0_0_0_rgba(255,255,255,0.06)]">
+      <aside className="hidden lg:flex w-60 flex-col flex-shrink-0 h-screen sticky top-0 bg-[#0a0a0a] shadow-[inset_-1px_0_0_0_rgba(255,255,255,0.06)]">
         {/* ヘッダー */}
         <div className="px-5 pt-5 pb-4">
           <p className="text-sm font-semibold">セールスパートナー</p>


### PR DESCRIPTION
## 概要
パートナー画面サイドバー下部のユーザー情報（プロフィール/ログアウト）が、本文のスクロールで画面外に流れていた問題を修正。

## 変更内容
[src/app/(partner)/layout.tsx](src/app/(partner)/layout.tsx) の `<aside>` に以下を追加:
- `h-screen` — 高さを画面と一致
- `sticky top-0` — 本文スクロール時も追従
- `flex-shrink-0` — 横幅が縮まらないように

管理ポータルの NavigationDrawer と同じパターン。

## Test plan
- [ ] パートナーで /partner/customers を開き本文をスクロール → 左サイドバー（特に下部の「管理専用」アバター部分）が常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)