### PR TITLE
備品管理: 商品画像アップロード失敗(413) を修正 - クライアント圧縮

### DIFF
--- a/src/components/admin/ProductImageUploader.tsx
+++ b/src/components/admin/ProductImageUploader.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
+import { compressImageIfNeeded } from '@/lib/image-utils'
 
 type Props = {
   value: string
@@ -13,16 +14,22 @@ export default function ProductImageUploader({ value, onChange, onError, disable
   const inputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
 
-  async function handleFile(file: File) {
-    if (!file.type.startsWith('image/')) {
+  async function handleFile(rawFile: File) {
+    if (!rawFile.type.startsWith('image/') && !rawFile.name.match(/\.(heic|heif)$/i)) {
       onError?.('画像ファイルのみアップロードできます')
       return
     }
     setUploading(true)
     try {
+      // クライアント側でリサイズ + JPEG 再エンコード（Vercel の 4.5MB body 上限対策）
+      const file = await compressImageIfNeeded(rawFile)
       const fd = new FormData()
       fd.append('file', file)
       const res = await fetch('/api/upload', { method: 'POST', body: fd })
+      if (res.status === 413) {
+        onError?.('画像のサイズが大きすぎます。別の画像をお試しください。')
+        return
+      }
       const data = await res.json().catch(() => ({}))
       if (!res.ok || !data.url) {
         onError?.(data.error ?? 'アップロードに失敗しました')

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -49,3 +49,66 @@ export async function appendImageToFormData(
   const converted = await convertToJpegIfNeeded(file)
   formData.append(fieldName, converted)
 }
+
+type CompressOptions = {
+  /** 長辺の最大ピクセル数。これ以下なら拡大しない */
+  maxDimension?: number
+  /** JPEG 品質 (0-1) */
+  quality?: number
+  /** これより小さければ何もしない（バイト） */
+  skipIfSmallerThan?: number
+}
+
+/**
+ * 画像をクライアント側でリサイズ・再エンコードし、Vercel のリクエスト上限
+ * (4.5MB) に収まるサイズに圧縮する。HEIC は先に JPEG へ変換する。
+ *
+ * - 既に十分小さい（既定 1.5MB 以下）場合はそのまま返す
+ * - JPEG/PNG/WEBP/HEIC 画像が対象。それ以外（GIF 等）はそのまま返す
+ * - 失敗した場合は元ファイルを返す（呼び出し側でハンドル）
+ */
+export async function compressImageIfNeeded(
+  file: File,
+  options: CompressOptions = {}
+): Promise<File> {
+  const { maxDimension = 2400, quality = 0.85, skipIfSmallerThan = 1.5 * 1024 * 1024 } = options
+
+  // HEIC は JPEG に変換
+  const input = await convertToJpegIfNeeded(file)
+
+  // 元から十分小さければそのまま
+  if (input.size <= skipIfSmallerThan) return input
+  // 画像でなければ手を出さない
+  if (!input.type.startsWith('image/')) return input
+  // ブラウザ外（SSR）では何もしない
+  if (typeof window === 'undefined' || typeof document === 'undefined') return input
+
+  try {
+    const blob: Blob = await new Promise((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => {
+        const ratio = Math.min(maxDimension / img.width, maxDimension / img.height, 1)
+        const width = Math.round(img.width * ratio)
+        const height = Math.round(img.height * ratio)
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        const ctx = canvas.getContext('2d')
+        if (!ctx) { reject(new Error('canvas ctx unavailable')); return }
+        ctx.drawImage(img, 0, 0, width, height)
+        canvas.toBlob(
+          (b) => b ? resolve(b) : reject(new Error('canvas.toBlob returned null')),
+          'image/jpeg',
+          quality,
+        )
+      }
+      img.onerror = () => reject(new Error('image decode failed'))
+      img.src = URL.createObjectURL(input)
+    })
+    const newName = input.name.replace(/\.[^.]+$/, '.jpg') || 'image.jpg'
+    return new File([blob], newName, { type: 'image/jpeg' })
+  } catch (e) {
+    console.warn('compressImageIfNeeded failed, falling back to original:', e)
+    return input
+  }
+}


### PR DESCRIPTION
## 概要
備品管理の商品追加モーダルで画像アップロードが「アップロードに失敗しました」となる問題を修正。

## 原因
Vercel サーバーレス関数の body 上限 (**4.5MB**) に引っかかって **413 Payload Too Large** が返されていた。サーバー側の 10MB 制限まで届く前に Vercel が弾いていた状態。iPhone のフル解像度写真は 5-10MB あるためこの上限を超えやすい。

(本番ログでも `GET /api/upload 413` が確認できた)

## 修正
クライアント側で送信前に画像をリサイズ + JPEG 再エンコードする。

- **[src/lib/image-utils.ts](src/lib/image-utils.ts)** に `compressImageIfNeeded()` を追加
  - 長辺 2400px にリサイズ（縮小のみ、拡大はしない）
  - JPEG 品質 0.85 で再エンコード
  - HEIC は既存の `convertToJpegIfNeeded` を経由してから処理
  - 既に 1.5MB 以下のファイルは加工せず通過（不必要な再エンコード回避）
  - SSR では何もしない（ブラウザ専用）
- **[src/components/admin/ProductImageUploader.tsx](src/components/admin/ProductImageUploader.tsx)** で送信前に呼び出し、413 時に分かりやすいメッセージ

## Test plan
- [ ] iPhone のフル解像度写真（5-10MB）を商品画像にアップロード → 成功
- [ ] HEIC ファイルをアップロード → JPEG 変換 + 圧縮されて成功
- [ ] 小さい画像（500KB 程度）をアップロード → 再エンコードされずそのまま成功
- [ ] 詳細ページの画像変更も同様に動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)