### PR TITLE
セールスパートナー画面に顧客CSVインポート機能を追加

### DIFF
--- a/prisma/migrations/20260513020000_add_partner_customer_import/migration.sql
+++ b/prisma/migrations/20260513020000_add_partner_customer_import/migration.sql
@@ -1,0 +1,20 @@
+-- セールスパートナーによる顧客CSVインポート履歴
+CREATE TABLE "PartnerCustomerImport" (
+  "id"           TEXT NOT NULL,
+  "partnerId"    TEXT NOT NULL,
+  "fileName"     TEXT NOT NULL,
+  "totalRows"    INTEGER NOT NULL,
+  "createdCount" INTEGER NOT NULL,
+  "updatedCount" INTEGER NOT NULL,
+  "errorCount"   INTEGER NOT NULL,
+  "errors"       JSONB,
+  "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "PartnerCustomerImport_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "PartnerCustomerImport_partnerId_idx" ON "PartnerCustomerImport"("partnerId");
+CREATE INDEX "PartnerCustomerImport_createdAt_idx" ON "PartnerCustomerImport"("createdAt");
+
+ALTER TABLE "PartnerCustomerImport" ADD CONSTRAINT "PartnerCustomerImport_partnerId_fkey"
+  FOREIGN KEY ("partnerId") REFERENCES "SalesPartner"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -888,6 +888,7 @@ model SalesPartner {
   acceptedAt   DateTime?                    // 招待受諾日時
   invitations  SalesPartnerInvitation[]
   customerNotes SalesPartnerCustomerNote[]
+  customerImports PartnerCustomerImport[]
   createdAt    DateTime                     @default(now())
   updatedAt    DateTime                     @updatedAt
 }
@@ -923,4 +924,21 @@ model SalesPartnerCustomerNote {
 
   @@unique([salesPartnerId, userId])
   @@index([userId])
+}
+
+// セールスパートナーによる顧客CSVインポート履歴
+model PartnerCustomerImport {
+  id            String       @id @default(cuid())
+  partnerId     String
+  partner       SalesPartner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
+  fileName      String
+  totalRows     Int                                              // ヘッダー除くデータ行数
+  createdCount  Int                                              // 新規作成行数
+  updatedCount  Int                                              // 更新行数
+  errorCount    Int                                              // エラー行数
+  errors        Json?                                            // [{row, licenseKey?, message}]
+  createdAt     DateTime     @default(now())
+
+  @@index([partnerId])
+  @@index([createdAt])
 }

--- a/src/app/(admin)/admin/partners/page.tsx
+++ b/src/app/(admin)/admin/partners/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
@@ -31,6 +31,18 @@ type Invitation = {
   salesPartner: { id: string; name: string } | null
 }
 
+type ImportLog = {
+  id: string
+  fileName: string
+  totalRows: number
+  createdCount: number
+  updatedCount: number
+  errorCount: number
+  errors: { row: number; licenseKey?: string; message: string }[] | null
+  createdAt: string
+  partner: { id: string; name: string; email: string } | null
+}
+
 const inputStyle: React.CSSProperties = {
   padding: '8px 10px', borderRadius: 6,
   border: '1px solid var(--md-sys-color-outline-variant)',
@@ -42,9 +54,11 @@ const inputStyle: React.CSSProperties = {
 export default function AdminPartnersPage() {
   const { data: session, status } = useSession()
   const router = useRouter()
-  const [tab, setTab] = useState<'partners' | 'invitations'>('partners')
+  const [tab, setTab] = useState<'partners' | 'invitations' | 'imports'>('partners')
   const [partners, setPartners] = useState<Partner[]>([])
   const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [imports, setImports] = useState<ImportLog[]>([])
+  const [expandedImportId, setExpandedImportId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [msg, setMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
@@ -65,9 +79,11 @@ export default function AdminPartnersPage() {
     Promise.all([
       fetch('/api/admin/partners').then(r => r.ok ? r.json() : []),
       fetch('/api/admin/partners/invitations').then(r => r.ok ? r.json() : []),
-    ]).then(([p, inv]) => {
+      fetch('/api/admin/partners/imports').then(r => r.ok ? r.json() : []),
+    ]).then(([p, inv, imp]) => {
       setPartners(p)
       setInvitations(inv)
+      setImports(imp)
     }).finally(() => setLoading(false))
   }
 
@@ -223,6 +239,12 @@ export default function AdminPartnersPage() {
         >
           招待リンク ({invitations.length})
         </button>
+        <button
+          onClick={() => setTab('imports')}
+          style={{ padding: '8px 16px', background: 'transparent', border: 'none', borderBottom: tab === 'imports' ? '2px solid var(--md-sys-color-primary)' : '2px solid transparent', color: tab === 'imports' ? 'var(--md-sys-color-primary)' : 'var(--md-sys-color-on-surface-variant)', fontWeight: 600, cursor: 'pointer' }}
+        >
+          インポート履歴 ({imports.length})
+        </button>
       </div>
 
       {tab === 'partners' && (
@@ -261,6 +283,83 @@ export default function AdminPartnersPage() {
                   </td>
                 </tr>
               ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {tab === 'imports' && (
+        <div style={{ background: 'var(--md-sys-color-surface-container-low)', borderRadius: 12, border: '1px solid var(--md-sys-color-outline-variant)', overflow: 'hidden' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+            <thead>
+              <tr style={{ background: 'var(--md-sys-color-surface-container)', textAlign: 'left' }}>
+                <th style={{ padding: '12px 16px', fontWeight: 600 }}>実行日時</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600 }}>パートナー</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600 }}>ファイル名</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>合計</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>新規</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>更新</th>
+                <th style={{ padding: '12px 16px', fontWeight: 600, textAlign: 'right' }}>エラー</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {imports.length === 0 ? (
+                <tr><td colSpan={8} style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--md-sys-color-on-surface-variant)' }}>インポート履歴はありません</td></tr>
+              ) : imports.map(log => {
+                const expanded = expandedImportId === log.id
+                const hasErrors = log.errorCount > 0 && log.errors && log.errors.length > 0
+                return (
+                  <Fragment key={log.id}>
+                    <tr style={{ borderTop: '1px solid var(--md-sys-color-outline-variant)' }}>
+                      <td style={{ padding: '12px 16px', fontSize: 12 }}>{format(new Date(log.createdAt), 'yyyy/M/d HH:mm', { locale: ja })}</td>
+                      <td style={{ padding: '12px 16px', fontSize: 13 }}>
+                        <div style={{ fontWeight: 600 }}>{log.partner?.name ?? '—'}</div>
+                        <div style={{ fontSize: 11, color: 'var(--md-sys-color-on-surface-variant)' }}>{log.partner?.email ?? ''}</div>
+                      </td>
+                      <td style={{ padding: '12px 16px', fontSize: 12, fontFamily: 'monospace' }}>{log.fileName}</td>
+                      <td style={{ padding: '12px 16px', textAlign: 'right', fontFamily: 'monospace' }}>{log.totalRows}</td>
+                      <td style={{ padding: '12px 16px', textAlign: 'right', fontFamily: 'monospace', color: '#66bb6a' }}>{log.createdCount}</td>
+                      <td style={{ padding: '12px 16px', textAlign: 'right', fontFamily: 'monospace', color: '#42a5f5' }}>{log.updatedCount}</td>
+                      <td style={{ padding: '12px 16px', textAlign: 'right', fontFamily: 'monospace', color: log.errorCount > 0 ? '#ef5350' : 'var(--md-sys-color-on-surface-variant)' }}>{log.errorCount}</td>
+                      <td style={{ padding: '12px 16px', textAlign: 'right' }}>
+                        {hasErrors && (
+                          <button
+                            onClick={() => setExpandedImportId(expanded ? null : log.id)}
+                            style={{ padding: '6px 12px', borderRadius: 6, background: 'transparent', color: 'var(--md-sys-color-primary)', border: '1px solid var(--md-sys-color-outline)', fontSize: 12, cursor: 'pointer' }}
+                          >
+                            {expanded ? '閉じる' : 'エラー詳細'}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                    {expanded && hasErrors && (
+                      <tr style={{ background: 'var(--md-sys-color-surface-container)' }}>
+                        <td colSpan={8} style={{ padding: '12px 16px' }}>
+                          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+                            <thead>
+                              <tr style={{ textAlign: 'left', color: 'var(--md-sys-color-on-surface-variant)' }}>
+                                <th style={{ padding: '6px 8px', width: 60 }}>行</th>
+                                <th style={{ padding: '6px 8px', width: 220 }}>ライセンスキー</th>
+                                <th style={{ padding: '6px 8px' }}>エラー内容</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {log.errors!.map((e, i) => (
+                                <tr key={i}>
+                                  <td style={{ padding: '4px 8px', fontFamily: 'monospace' }}>{e.row}</td>
+                                  <td style={{ padding: '4px 8px', fontFamily: 'monospace' }}>{e.licenseKey ?? '—'}</td>
+                                  <td style={{ padding: '4px 8px', color: '#ef5350' }}>{e.message}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/src/app/(partner)/partner/customers/import/page.tsx
+++ b/src/app/(partner)/partner/customers/import/page.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+type RowError = { row: number; licenseKey?: string; message: string }
+type ImportResult = {
+  totalRows: number
+  createdCount: number
+  updatedCount: number
+  errorCount: number
+  errors: RowError[]
+}
+
+export default function PartnerCustomerImportPage() {
+  const { status } = useSession()
+  const router = useRouter()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [result, setResult] = useState<ImportResult | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/partner/login')
+  }, [status, router])
+
+  async function handleUpload(e: React.FormEvent) {
+    e.preventDefault()
+    if (!file) return
+    setUploading(true)
+    setErrorMsg(null)
+    setResult(null)
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch('/api/partner/customers/import', { method: 'POST', body: fd })
+    const data = await res.json().catch(() => ({}))
+    setUploading(false)
+    if (!res.ok) {
+      setErrorMsg(data.error ?? 'アップロードに失敗しました')
+      return
+    }
+    setResult(data as ImportResult)
+    setFile(null)
+    if (fileRef.current) fileRef.current.value = ''
+  }
+
+  if (status !== 'authenticated') return null
+
+  return (
+    <div className="px-6 py-8 max-w-4xl mx-auto">
+      <div className="flex items-center gap-3 mb-1">
+        <Link href="/partner/customers" className="text-xs text-[#a3a3a3] hover:text-white">← 顧客一覧に戻る</Link>
+      </div>
+      <h1 className="text-2xl font-bold mb-1">CSV インポート</h1>
+      <p className="text-sm text-[#a3a3a3] mb-6">ライセンスキーをキーに、顧客情報を一括で新規登録／更新します。</p>
+
+      <section className="rounded-2xl border border-[rgba(255,255,255,0.06)] bg-[#0f0f0f] p-5 mb-6">
+        <h2 className="text-sm font-semibold mb-2">1. テンプレートをダウンロード</h2>
+        <p className="text-xs text-[#a3a3a3] mb-3">
+          列：<code>ライセンスキー*</code> / <code>氏名*</code> / <code>フリガナ</code> / <code>メール</code> / <code>電話</code> / <code>住所</code>
+        </p>
+        <a
+          href="/api/partner/customers/import"
+          className="inline-flex items-center px-4 py-2 rounded-md bg-[#1f1f1f] hover:bg-[#262626] text-sm border border-[rgba(255,255,255,0.08)]"
+        >
+          テンプレート CSV をダウンロード
+        </a>
+      </section>
+
+      <form onSubmit={handleUpload} className="rounded-2xl border border-[rgba(255,255,255,0.06)] bg-[#0f0f0f] p-5 mb-6">
+        <h2 className="text-sm font-semibold mb-3">2. CSV をアップロード</h2>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv,text/csv"
+          onChange={e => setFile(e.target.files?.[0] ?? null)}
+          className="block w-full text-sm text-[#a3a3a3] file:mr-3 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:bg-[#1f1f1f] file:text-white hover:file:bg-[#262626] mb-4"
+        />
+        <button
+          type="submit"
+          disabled={!file || uploading}
+          className="px-4 py-2 rounded-md bg-white text-black text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {uploading ? '取込中…' : 'インポート実行'}
+        </button>
+        <p className="text-[11px] text-[#666] mt-3">
+          ・ライセンスキー未使用の行は新規顧客として登録（仮パスワード自動生成）<br />
+          ・既存顧客はライセンスキーで照合して更新（空欄列はスキップ）<br />
+          ・存在しないライセンスキーや必須欠落の行はエラーとして報告
+        </p>
+      </form>
+
+      {errorMsg && (
+        <div className="rounded-md p-3 mb-4 text-sm bg-red-500/10 text-red-300 border border-red-500/30">
+          {errorMsg}
+        </div>
+      )}
+
+      {result && (
+        <section className="rounded-2xl border border-[rgba(255,255,255,0.06)] bg-[#0f0f0f] p-5">
+          <h2 className="text-sm font-semibold mb-3">取込結果</h2>
+          <div className="grid grid-cols-4 gap-3 mb-4">
+            <Stat label="合計行" value={result.totalRows} />
+            <Stat label="新規" value={result.createdCount} tone="ok" />
+            <Stat label="更新" value={result.updatedCount} tone="ok" />
+            <Stat label="エラー" value={result.errorCount} tone={result.errorCount > 0 ? 'ng' : undefined} />
+          </div>
+          {result.errors.length > 0 && (
+            <div className="rounded-md border border-[rgba(255,255,255,0.06)] overflow-hidden">
+              <table className="w-full text-xs">
+                <thead className="bg-[#141414] text-[#a3a3a3]">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-semibold w-16">行</th>
+                    <th className="px-3 py-2 text-left font-semibold w-56">ライセンスキー</th>
+                    <th className="px-3 py-2 text-left font-semibold">エラー</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.errors.map((e, i) => (
+                    <tr key={i} className="border-t border-[rgba(255,255,255,0.06)]">
+                      <td className="px-3 py-2 font-mono">{e.row}</td>
+                      <td className="px-3 py-2 font-mono">{e.licenseKey ?? '—'}</td>
+                      <td className="px-3 py-2 text-red-300">{e.message}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, tone }: { label: string; value: number; tone?: 'ok' | 'ng' }) {
+  const color = tone === 'ok' ? 'text-emerald-300' : tone === 'ng' ? 'text-red-300' : 'text-[#ededed]'
+  return (
+    <div className="rounded-md bg-[#141414] border border-[rgba(255,255,255,0.06)] px-3 py-2">
+      <div className="text-[10px] text-[#666] mb-0.5">{label}</div>
+      <div className={`text-xl font-bold ${color}`}>{value}</div>
+    </div>
+  )
+}

--- a/src/app/(partner)/partner/customers/page.tsx
+++ b/src/app/(partner)/partner/customers/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
 type Customer = {
   id: string
@@ -56,7 +57,15 @@ export default function PartnerCustomersPage() {
 
   return (
     <div className="px-6 py-8 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-bold mb-1">ライセンスキー顧客</h1>
+      <div className="flex items-center justify-between gap-3 mb-1 flex-wrap">
+        <h1 className="text-2xl font-bold">ライセンスキー顧客</h1>
+        <Link
+          href="/partner/customers/import"
+          className="px-3 py-1.5 rounded-md bg-white text-black text-xs font-semibold hover:bg-[#e5e5e5]"
+        >
+          + CSV インポート
+        </Link>
+      </div>
       <p className="text-sm text-[#a3a3a3] mb-6">{filtered.length} 件 / 全 {customers.length} 件</p>
 
       <input

--- a/src/app/api/admin/partners/imports/route.ts
+++ b/src/app/api/admin/partners/imports/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { requireAdmin } from '@/lib/admin-auth'
+
+/** セールスパートナーによる顧客CSVインポート履歴一覧 */
+export async function GET() {
+  const user = await requireAdmin()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const imports = await prisma.partnerCustomerImport.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 200,
+    include: { partner: { select: { id: true, name: true, email: true } } },
+  })
+  return NextResponse.json(imports)
+}

--- a/src/app/api/partner/customers/import/route.ts
+++ b/src/app/api/partner/customers/import/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import bcrypt from 'bcryptjs'
+import { prisma } from '@/lib/prisma'
+import { requirePartner } from '@/lib/partner-auth'
+import { parseCsv, buildCsv } from '@/lib/csv-parser'
+
+const COLUMNS: { header: string; field: 'licenseKey' | 'name' | 'furigana' | 'email' | 'phone' | 'address'; required?: boolean }[] = [
+  { header: 'ライセンスキー', field: 'licenseKey', required: true },
+  { header: '氏名',           field: 'name',       required: true },
+  { header: 'フリガナ',       field: 'furigana' },
+  { header: 'メール',         field: 'email' },
+  { header: '電話',           field: 'phone' },
+  { header: '住所',           field: 'address' },
+]
+
+type RowError = { row: number; licenseKey?: string; message: string }
+
+/** GET: CSV テンプレートをダウンロード */
+export async function GET() {
+  const partner = await requirePartner()
+  if (!partner) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const headers = COLUMNS.map(c => c.required ? `${c.header}*` : c.header)
+  const sample = ['LICENSE-XXXX', '山田 太郎', 'ヤマダ タロウ', 'yamada@example.com', '090-1234-5678', '東京都渋谷区...']
+  const csv = buildCsv([headers, sample])
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="partner-customers-template.csv"',
+    },
+  })
+}
+
+/** POST: CSV をパースしてライセンスキー紐づけ顧客を作成/更新 */
+export async function POST(req: NextRequest) {
+  const partner = await requirePartner()
+  if (!partner) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const contentType = req.headers.get('content-type') ?? ''
+  if (!contentType.includes('multipart/form-data')) {
+    return NextResponse.json({ error: 'multipart/form-data で送信してください' }, { status: 400 })
+  }
+
+  const formData = await req.formData()
+  const file = formData.get('file') as File | null
+  if (!file) return NextResponse.json({ error: 'ファイルが選択されていません' }, { status: 400 })
+  if (file.size > 5 * 1024 * 1024) {
+    return NextResponse.json({ error: 'ファイルサイズは5MB以下にしてください' }, { status: 400 })
+  }
+
+  const csvText = await file.text()
+  const rows = parseCsv(csvText)
+  if (rows.length < 2) {
+    return NextResponse.json({ error: 'ヘッダー行とデータ行が必要です' }, { status: 400 })
+  }
+
+  // ヘッダー解析
+  const headerRow = rows[0].map(h => h.trim().replace(/\*+$/, ''))
+  const idxOf: Record<string, number> = {}
+  for (let i = 0; i < headerRow.length; i++) idxOf[headerRow[i]] = i
+
+  const missing = COLUMNS.filter(c => c.required && !(c.header in idxOf)).map(c => c.header)
+  if (missing.length > 0) {
+    return NextResponse.json({ error: `必須列が見つかりません: ${missing.join(', ')}` }, { status: 400 })
+  }
+
+  const get = (row: string[], header: string) => {
+    const idx = idxOf[header]
+    return idx === undefined ? '' : (row[idx] ?? '').trim()
+  }
+
+  // 1) ライセンスキーをまとめて取得（user 付き）
+  const keys = new Set<string>()
+  for (let r = 1; r < rows.length; r++) {
+    const k = get(rows[r], 'ライセンスキー')
+    if (k) keys.add(k)
+  }
+  const licenseKeys = await prisma.licenseKey.findMany({
+    where: { key: { in: [...keys] } },
+    include: { user: { select: { id: true } } },
+  })
+  const keyMap = new Map(licenseKeys.map(lk => [lk.key, lk]))
+
+  const errors: RowError[] = []
+  let createdCount = 0
+  let updatedCount = 0
+  const totalRows = rows.length - 1
+
+  // 2) 行ごとに処理（順次トランザクション外で OK：エラーは行単位で集計）
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r]
+    const lineNo = r + 1
+    const licenseKey = get(row, 'ライセンスキー')
+    const name = get(row, '氏名')
+
+    if (!licenseKey) { errors.push({ row: lineNo, message: 'ライセンスキーが空です' }); continue }
+    if (!name)       { errors.push({ row: lineNo, licenseKey, message: '氏名が空です' }); continue }
+
+    const lk = keyMap.get(licenseKey)
+    if (!lk) {
+      errors.push({ row: lineNo, licenseKey, message: `ライセンスキー "${licenseKey}" が登録されていません` })
+      continue
+    }
+
+    const emailRaw = get(row, 'メール')
+    const email = emailRaw || null
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      errors.push({ row: lineNo, licenseKey, message: `メール形式が不正: "${email}"` })
+      continue
+    }
+
+    const furigana = get(row, 'フリガナ')
+    const phone    = get(row, '電話')
+    const address  = get(row, '住所')
+
+    try {
+      if (lk.user) {
+        // 更新（空欄カラムは上書きしない）
+        const data: Record<string, unknown> = { name }
+        if (furigana) data.furigana = furigana
+        if (phone)    data.phone    = phone
+        if (address)  data.address  = address
+        if (emailRaw !== '') data.email = email
+        await prisma.user.update({ where: { id: lk.user.id }, data })
+        updatedCount++
+      } else {
+        // 新規作成：仮パスワードを自動生成
+        const tempPassword = await bcrypt.hash(crypto.randomBytes(24).toString('hex'), 10)
+        await prisma.$transaction([
+          prisma.user.create({
+            data: {
+              name,
+              furigana: furigana || '',
+              phone:    phone    || '',
+              address:  address  || '',
+              email,
+              password: tempPassword,
+              licenseKeyId: lk.id,
+            },
+          }),
+          prisma.licenseKey.update({ where: { id: lk.id }, data: { isUsed: true } }),
+        ])
+        createdCount++
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e)
+      errors.push({ row: lineNo, licenseKey, message: `保存に失敗: ${message}` })
+    }
+  }
+
+  // 3) 履歴を保存
+  await prisma.partnerCustomerImport.create({
+    data: {
+      partnerId:    partner.id,
+      fileName:     file.name || 'upload.csv',
+      totalRows,
+      createdCount,
+      updatedCount,
+      errorCount:   errors.length,
+      errors:       errors.length > 0 ? errors : undefined,
+    },
+  })
+
+  return NextResponse.json({ totalRows, createdCount, updatedCount, errorCount: errors.length, errors })
+}


### PR DESCRIPTION
## Summary
- セールスパートナー画面に CSV インポート機能を追加（`/partner/customers/import`）
- ライセンスキーをキーに、未使用キーは新規 User 作成（仮パスワード自動生成）、既存は更新
- 管理ポータル `/admin/partners` に「インポート履歴」タブを追加し、エラー行詳細まで閲覧可能
- Prisma に `PartnerCustomerImport` モデル + migration を同梱

## CSV テンプレート
列: `ライセンスキー*, 氏名*, フリガナ, メール, 電話, 住所`

## Test plan
- [ ] パートナーでログインし `/partner/customers` から「+ CSV インポート」を開く
- [ ] テンプレートCSVをダウンロードし、ライセンスキー＋氏名を入れてアップロード
- [ ] 未使用ライセンスキー行: 新規顧客が作成される / 使用済み行: 更新される
- [ ] 存在しないライセンスキー・空セルがエラーとして表示される
- [ ] 管理者でログインし `/admin/partners` → 「インポート履歴」タブで結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)